### PR TITLE
Add scrollbars to tool and canvas sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
     font-synthesis-weight:none;
   }
   * { box-sizing: border-box; }
-  body { margin: 0; font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans JP", sans-serif; }
+  html, body { margin: 0; font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans JP", sans-serif; overflow: hidden; }
 
   /* ← 固定高さをやめて自動高さ。折り返しやオーバーフローに強くする */
   header, footer {
@@ -28,7 +28,7 @@
   /* ← グリッドの行高も auto に変更（以前は var(--ui) で固定だった） */
   #app { display: grid; grid-template-rows: auto 1fr auto; height: 100dvh; }
 
-  #stage { position: relative; background: #f6f6f6; overflow: hidden; }
+  #stage { position: relative; background: #f6f6f6; overflow: auto; }
   canvas { position: absolute; inset: 0; image-rendering: pixelated; z-index: 0; }
   #overlay { pointer-events: none; z-index: 1; }
 
@@ -47,13 +47,16 @@
     display: flex;
     align-items: center;
     gap: var(--gap);
-    overflow-x: auto;
+    overflow: auto;
     white-space: nowrap;
     flex: 1 1 auto;
     padding-bottom: 2px; /* スクロールバー余白 */
   }
   #tools::-webkit-scrollbar { height: 8px; }
   #tools::-webkit-scrollbar-thumb { background: #ccc; border-radius: 4px; }
+
+  #stage::-webkit-scrollbar { width: 8px; height: 8px; }
+  #stage::-webkit-scrollbar-thumb { background: #ccc; border-radius: 4px; }
 
   button, select, input[type="color"], input[type="number"] { height: 28px; }
   .tool { padding: 4px 8px; flex: none; }


### PR DESCRIPTION
## Summary
- enable scrollbars for top tool strip and canvas area
- style scrollbars for consistent appearance
- hide outer document scrollbar so only tool strip and canvas scroll independently

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689cff639870832482bd37c08ff4f049