### PR TITLE
Wrap tools toolbar into two rows

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,7 +48,8 @@
     display:flex;
     align-items:center;
     gap:var(--gap);
-    white-space:nowrap;
+    flex-wrap:wrap;                        /* 2行に折り返し */
+    white-space:normal;
     flex:1 1 auto;
     padding-bottom:2px;
     overflow:auto;                         /* ← autoでOK */


### PR DESCRIPTION
## Summary
- Allow the tools toolbar to wrap onto two lines by enabling flex wrapping and normal whitespace handling.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d248d23d883249bfff41be2276b2e