### PR TITLE
Implement four-click cubic Bézier workflow

### DIFF
--- a/index.html
+++ b/index.html
@@ -474,21 +474,54 @@ function makeCubic(store){
     id:'cubic',cursor:'crosshair',previewRect:null,
     onPointerDown(ctx,ev,eng){
       if(stage===0){ p0={...ev.img}; stage=1; }
-      else if(stage===1){ p3={...ev.img}; const mx=(p0.x+p3.x)/2,my=(p0.y+p3.y)/2; p1={x:mx,y:my}; p2={x:mx,y:my}; stage=2; }
-      else if(stage===2){ const s=store.getState(); ctx.save(); ctx.lineWidth=s.brushSize; ctx.strokeStyle=s.primaryColor; ctx.beginPath(); ctx.moveTo(p0.x+0.5,p0.y+0.5); ctx.bezierCurveTo(p1.x+0.5,p1.y+0.5,p2.x+0.5,p2.y+0.5,p3.x+0.5,p3.y+0.5); ctx.stroke(); ctx.restore(); const minX=Math.min(p0.x,p1.x,p2.x,p3.x), minY=Math.min(p0.y,p1.y,p2.y,p3.y), maxX=Math.max(p0.x,p1.x,p2.x,p3.x), maxY=Math.max(p0.y,p1.y,p2.y,p3.y); eng.expandPendingRectByRect(minX-s.brushSize,minY-s.brushSize,maxX-minX+s.brushSize*2,maxY-minY+s.brushSize*2); stage=0; this.previewRect=null; }
-    },
-    onPointerMove(ctx,ev){
-      if(stage===2){
-        if(ev.shift){
-          p2={...ev.img};
-        } else {
-          p1={...ev.img};
-          p2={x:p0.x+p3.x-p1.x,y:p0.y+p3.y-p1.y};
-        }
+      else if(stage===1){ p1={...ev.img}; stage=2; }
+      else if(stage===2){ p2={...ev.img}; stage=3; }
+      else if(stage===3){
+        p3={...ev.img};
+        const s=store.getState();
+        ctx.save();
+        ctx.lineWidth=s.brushSize;
+        ctx.strokeStyle=s.primaryColor;
+        ctx.beginPath();
+        ctx.moveTo(p0.x+0.5,p0.y+0.5);
+        ctx.bezierCurveTo(p1.x+0.5,p1.y+0.5,p2.x+0.5,p2.y+0.5,p3.x+0.5,p3.y+0.5);
+        ctx.stroke();
+        ctx.restore();
+        const minX=Math.min(p0.x,p1.x,p2.x,p3.x), minY=Math.min(p0.y,p1.y,p2.y,p3.y), maxX=Math.max(p0.x,p1.x,p2.x,p3.x), maxY=Math.max(p0.y,p1.y,p2.y,p3.y);
+        eng.expandPendingRectByRect(minX-s.brushSize,minY-s.brushSize,maxX-minX+s.brushSize*2,maxY-minY+s.brushSize*2);
+        stage=0; this.previewRect=null;
       }
     },
+    onPointerMove(ctx,ev){
+      if(stage===1){ p1={...ev.img}; }
+      else if(stage===2){ p2={...ev.img}; }
+      else if(stage===3){ p3={...ev.img}; }
+    },
     onPointerUp(){},
-    drawPreview(octx){ if(stage===2){ const s=store.getState(); octx.save(); octx.lineWidth=s.brushSize; octx.strokeStyle=s.primaryColor; octx.beginPath(); octx.moveTo(p0.x+0.5,p0.y+0.5); octx.bezierCurveTo(p1.x+0.5,p1.y+0.5,p2.x+0.5,p2.y+0.5,p3.x+0.5,p3.y+0.5); octx.stroke(); octx.restore(); } }
+    drawPreview(octx){
+      const s=store.getState();
+      octx.save();
+      octx.lineWidth=s.brushSize;
+      octx.strokeStyle=s.primaryColor;
+      if(stage===1 && p0 && p1){
+        octx.beginPath();
+        octx.moveTo(p0.x+0.5,p0.y+0.5);
+        octx.lineTo(p1.x+0.5,p1.y+0.5);
+        octx.stroke();
+      } else if(stage===2 && p0 && p1 && p2){
+        octx.beginPath();
+        octx.moveTo(p0.x+0.5,p0.y+0.5);
+        octx.lineTo(p1.x+0.5,p1.y+0.5);
+        octx.lineTo(p2.x+0.5,p2.y+0.5);
+        octx.stroke();
+      } else if(stage===3 && p0 && p1 && p2 && p3){
+        octx.beginPath();
+        octx.moveTo(p0.x+0.5,p0.y+0.5);
+        octx.bezierCurveTo(p1.x+0.5,p1.y+0.5,p2.x+0.5,p2.y+0.5,p3.x+0.5,p3.y+0.5);
+        octx.stroke();
+      }
+      octx.restore();
+    }
   }; }
 
 function makeArc(store){


### PR DESCRIPTION
## Summary
- Change cubic Bézier tool to use separate clicks for start point, control point 1, control point 2, and end point
- Add stage-aware preview rendering for intermediate clicks

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d553a959c832492839d8fcfe4edd1