### PR TITLE
Enable double-click to finalize Catmull-Rom tool

### DIFF
--- a/index.html
+++ b/index.html
@@ -523,7 +523,13 @@ function catmullRomSpline(pts,seg=16){ const out=[]; if(pts.length<2) return pts
 function makeCatmull(store){ let pts=[]; function finalize(ctx,eng){ if(pts.length<4) return; const s=store.getState(); const cr=catmullRomSpline(pts); ctx.save(); ctx.lineWidth=s.brushSize; ctx.strokeStyle=s.primaryColor; ctx.beginPath(); ctx.moveTo(cr[0].x+0.5,cr[0].y+0.5); for(let i=1;i<cr.length;i++) ctx.lineTo(cr[i].x+0.5,cr[i].y+0.5); ctx.stroke(); ctx.restore(); let minX=cr[0].x,maxX=cr[0].x,minY=cr[0].y,maxY=cr[0].y; cr.forEach(p=>{minX=Math.min(minX,p.x);maxX=Math.max(maxX,p.x);minY=Math.min(minY,p.y);maxY=Math.max(maxY,p.y);}); eng.expandPendingRectByRect(minX-s.brushSize,minY-s.brushSize,maxX-minX+s.brushSize*2,maxY-minY+s.brushSize*2); eng.finishStrokeToHistory(); eng.requestRepaint(); pts=[]; }
   window.addEventListener('keydown',e=>{ if(e.key==='Enter') finalize(bctx,engine); });
   return { id:'catmull',cursor:'crosshair',previewRect:null,
-    onPointerDown(ctx,ev){ pts.push({...ev.img}); },
+    onPointerDown(ctx,ev){
+      if(ev.detail===2){
+        finalize(ctx, engine);
+        return;
+      }
+      pts.push({...ev.img});
+    },
     onPointerMove(){}, onPointerUp(){}, drawPreview(octx){ if(pts.length>1){ const cr=catmullRomSpline(pts); octx.save(); octx.lineWidth=store.getState().brushSize; octx.strokeStyle=store.getState().primaryColor; octx.beginPath(); octx.moveTo(cr[0].x+0.5,cr[0].y+0.5); for(let i=1;i<cr.length;i++) octx.lineTo(cr[i].x+0.5,cr[i].y+0.5); octx.stroke(); octx.restore(); } } };
 }
 


### PR DESCRIPTION
## Summary
- Allow double-clicking to finalize Catmull-Rom strokes
- Start new Catmull-Rom stroke on the first click after finalization

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d5661302c8324ae095818764e4843