### PR TITLE
Ensure new curve starts after confirming

### DIFF
--- a/index.html
+++ b/index.html
@@ -286,7 +286,11 @@ class Engine{
     const tick=()=>{ this._antsPhase=(this._antsPhase+1)%16; this.requestRepaint(); requestAnimationFrame(tick); };
     requestAnimationFrame(tick);
   }
-  setTool(id){ this.current=this.tools.get(id); base.style.cursor=this.current?.cursor||'default'; }
+  setTool(id){
+    if(this.current && this.current.cancel) this.current.cancel();
+    this.current=this.tools.get(id);
+    base.style.cursor=this.current?.cursor||'default';
+  }
   register(t){ this.tools.set(t.id,t); }
   clearSelection(){ this.selection=null; this.current && (this.current.previewRect=null); }
   pointInRect(p,r){ return p.x>=r.x&&p.y>=r.y&&p.x<r.x+r.w&&p.y<r.y+r.h; }
@@ -370,6 +374,12 @@ stage.addEventListener('pointerdown', e=>{
   }
 });
 
+    stage.addEventListener('contextmenu', e=>{
+      e.preventDefault();
+      this.current?.cancel?.();
+      this.requestRepaint();
+    });
+
 
     stage.addEventListener('pointermove', e=>{
       const p=pointer(e);
@@ -394,6 +404,7 @@ window.addEventListener('keydown', e=>{
     return; // ← P/T/Space/Undo など全部無効
   }
 
+  if(e.code==='Escape'){ e.preventDefault(); this.current?.cancel?.(); this.requestRepaint(); return; }
   if(e.code==='Space'){ e.preventDefault(); base.style.cursor='grab'; } // パン開始フラグはpointermove側で見る
   if((e.ctrlKey||e.metaKey)&&e.code==='KeyZ'){ e.preventDefault(); engine.undo(); }
   if((e.ctrlKey||e.metaKey)&&e.code==='KeyY'){ e.preventDefault(); engine.redo(); }
@@ -553,17 +564,31 @@ function makeSector(store){
 function catmullRom(p0,p1,p2,p3,t){ const t2=t*t,t3=t2*t; return { x:0.5*((2*p1.x)+(-p0.x+p2.x)*t+(2*p0.x-5*p1.x+4*p2.x-p3.x)*t2+(-p0.x+3*p1.x-3*p2.x+p3.x)*t3), y:0.5*((2*p1.y)+(-p0.y+p2.y)*t+(2*p0.y-5*p1.y+4*p2.y-p3.y)*t2+(-p0.y+3*p1.y-3*p2.y+p3.y)*t3) }; }
 function catmullRomSpline(pts,seg=16){ const out=[]; if(pts.length<2) return pts; for(let i=0;i<pts.length-1;i++){ const p0=pts[i-1]||pts[i],p1=pts[i],p2=pts[i+1],p3=pts[i+2]||p2; for(let j=0;j<=seg;j++){ const t=j/seg; out.push(catmullRom(p0,p1,p2,p3,t)); } } return out; }
 
-function makeCatmull(store){ let pts=[]; function finalize(ctx,eng){ if(pts.length<4){ pts=[]; eng.requestRepaint(); return; } const s=store.getState(); const cr=catmullRomSpline(pts); ctx.save(); ctx.lineWidth=s.brushSize; ctx.strokeStyle=s.primaryColor; ctx.beginPath(); ctx.moveTo(cr[0].x+0.5,cr[0].y+0.5); for(let i=1;i<cr.length;i++) ctx.lineTo(cr[i].x+0.5,cr[i].y+0.5); ctx.stroke(); ctx.restore(); let minX=cr[0].x,maxX=cr[0].x,minY=cr[0].y,maxY=cr[0].y; cr.forEach(p=>{minX=Math.min(minX,p.x);maxX=Math.max(maxX,p.x);minY=Math.min(minY,p.y);maxY=Math.max(maxY,p.y);}); eng.expandPendingRectByRect(minX-s.brushSize,minY-s.brushSize,maxX-minX+s.brushSize*2,maxY-minY+s.brushSize*2); eng.finishStrokeToHistory(); eng.requestRepaint(); pts=[]; }
+function makeCatmull(store){
+  let pts=[], fresh=true;
+  const reset=()=>{ pts=[]; fresh=true; };
+  function finalize(ctx,eng){
+    if(pts.length<4){ reset(); eng.requestRepaint(); return; }
+    const s=store.getState(); const cr=catmullRomSpline(pts);
+    ctx.save(); ctx.lineWidth=s.brushSize; ctx.strokeStyle=s.primaryColor;
+    ctx.beginPath(); ctx.moveTo(cr[0].x+0.5,cr[0].y+0.5); for(let i=1;i<cr.length;i++) ctx.lineTo(cr[i].x+0.5,cr[i].y+0.5); ctx.stroke(); ctx.restore();
+    let minX=cr[0].x,maxX=cr[0].x,minY=cr[0].y,maxY=cr[0].y;
+    cr.forEach(p=>{minX=Math.min(minX,p.x);maxX=Math.max(maxX,p.x);minY=Math.min(minY,p.y);maxY=Math.max(maxY,p.y);});
+    eng.expandPendingRectByRect(minX-s.brushSize,minY-s.brushSize,maxX-minX+s.brushSize*2,maxY-minY+s.brushSize*2);
+    eng.finishStrokeToHistory(); eng.requestRepaint(); reset();
+  }
   window.addEventListener('keydown',e=>{ if(e.key==='Enter') finalize(bctx,engine); });
-  return { id:'catmull',cursor:'crosshair',previewRect:null,
+  return {
+    id:'catmull',cursor:'crosshair',previewRect:null,
+    cancel(){ reset(); engine.requestRepaint(); },
     onPointerDown(ctx,ev){
-      if(ev.detail===2){
-        finalize(ctx, engine);
-        return;
-      }
+      if(ev.detail===2){ finalize(ctx, engine); return; }
+      if(fresh){ pts=[]; fresh=false; }
       pts.push({...ev.img});
     },
-    onPointerMove(){}, onPointerUp(){}, drawPreview(octx){ if(pts.length>1){ const cr=catmullRomSpline(pts); octx.save(); octx.lineWidth=store.getState().brushSize; octx.strokeStyle=store.getState().primaryColor; octx.beginPath(); octx.moveTo(cr[0].x+0.5,cr[0].y+0.5); for(let i=1;i<cr.length;i++) octx.lineTo(cr[i].x+0.5,cr[i].y+0.5); octx.stroke(); octx.restore(); } } };
+    onPointerMove(){}, onPointerUp(){},
+    drawPreview(octx){ if(pts.length>1){ const cr=catmullRomSpline(pts); octx.save(); octx.lineWidth=store.getState().brushSize; octx.strokeStyle=store.getState().primaryColor; octx.beginPath(); octx.moveTo(cr[0].x+0.5,cr[0].y+0.5); for(let i=1;i<cr.length;i++) octx.lineTo(cr[i].x+0.5,cr[i].y+0.5); octx.stroke(); octx.restore(); } }
+  };
 }
 
 function bspline(points,deg=3,seg=32){
@@ -597,11 +622,27 @@ function deBoor(k,u,t,c,j){
   return d[k];
 }
 
-function makeBSpline(store){ let pts=[], fresh=true; function finalize(ctx,eng){ if(pts.length<4){ pts=[]; fresh=true; eng.requestRepaint(); return; } const s=store.getState(); const cr=bspline(pts); ctx.save(); ctx.lineWidth=s.brushSize; ctx.strokeStyle=s.primaryColor; ctx.beginPath(); ctx.moveTo(cr[0].x+0.5,cr[0].y+0.5); for(let i=1;i<cr.length;i++) ctx.lineTo(cr[i].x+0.5,cr[i].y+0.5); ctx.stroke(); ctx.restore(); let minX=cr[0].x,maxX=cr[0].x,minY=cr[0].y,maxY=cr[0].y; cr.forEach(p=>{minX=Math.min(minX,p.x);maxX=Math.max(maxX,p.x);minY=Math.min(minY,p.y);maxY=Math.max(maxY,p.y);}); eng.expandPendingRectByRect(minX-s.brushSize,minY-s.brushSize,maxX-minX+s.brushSize*2,maxY-minY+s.brushSize*2); eng.finishStrokeToHistory(); eng.requestRepaint(); pts=[]; fresh=true; }
+function makeBSpline(store){
+  let pts=[], fresh=true;
+  const reset=()=>{ pts=[]; fresh=true; };
+  function finalize(ctx,eng){
+    if(pts.length<4){ reset(); eng.requestRepaint(); return; }
+    const s=store.getState(); const cr=bspline(pts);
+    ctx.save(); ctx.lineWidth=s.brushSize; ctx.strokeStyle=s.primaryColor;
+    ctx.beginPath(); ctx.moveTo(cr[0].x+0.5,cr[0].y+0.5); for(let i=1;i<cr.length;i++) ctx.lineTo(cr[i].x+0.5,cr[i].y+0.5); ctx.stroke(); ctx.restore();
+    let minX=cr[0].x,maxX=cr[0].x,minY=cr[0].y,maxY=cr[0].y;
+    cr.forEach(p=>{minX=Math.min(minX,p.x);maxX=Math.max(maxX,p.x);minY=Math.min(minY,p.y);maxY=Math.max(maxY,p.y);});
+    eng.expandPendingRectByRect(minX-s.brushSize,minY-s.brushSize,maxX-minX+s.brushSize*2,maxY-minY+s.brushSize*2);
+    eng.finishStrokeToHistory(); eng.requestRepaint(); reset();
+  }
   window.addEventListener('keydown',e=>{ if(e.key==='Enter') finalize(bctx,engine); });
-  return { id:'bspline',cursor:'crosshair',previewRect:null,
+  return {
+    id:'bspline',cursor:'crosshair',previewRect:null,
+    cancel(){ reset(); engine.requestRepaint(); },
     onPointerDown(ctx,ev){ if(ev.detail===2){ finalize(ctx, engine); return; } if(fresh){ pts=[]; fresh=false; } pts.push({...ev.img}); },
-    onPointerMove(){}, onPointerUp(){}, drawPreview(octx){ if(pts.length>1){ const cr=bspline(pts); octx.save(); octx.lineWidth=store.getState().brushSize; octx.strokeStyle=store.getState().primaryColor; octx.beginPath(); octx.moveTo(cr[0].x+0.5,cr[0].y+0.5); for(let i=1;i<cr.length;i++) octx.lineTo(cr[i].x+0.5,cr[i].y+0.5); octx.stroke(); octx.restore(); } } };
+    onPointerMove(){}, onPointerUp(){},
+    drawPreview(octx){ if(pts.length>1){ const cr=bspline(pts); octx.save(); octx.lineWidth=store.getState().brushSize; octx.strokeStyle=store.getState().primaryColor; octx.beginPath(); octx.moveTo(cr[0].x+0.5,cr[0].y+0.5); for(let i=1;i<cr.length;i++) octx.lineTo(cr[i].x+0.5,cr[i].y+0.5); octx.stroke(); octx.restore(); } }
+  };
 }
 
 function nurbs(points,weights,deg=3,seg=32){ const n=points.length-1; const knots=[]; for(let i=0;i<=n+deg+1;i++) knots.push(i); function N(i,k,u){ if(k===0) return (u>=knots[i]&&u<knots[i+1])?1:0; const a=(u-knots[i])/(knots[i+k]-knots[i])||0; const b=(knots[i+k+1]-u)/(knots[i+k+1]-knots[i+1])||0; return a*N(i,k-1,u)+b*N(i+1,k-1,u); } const domain=[deg, knots.length-deg-1]; const out=[]; const step=(knots[domain[1]]-knots[domain[0]])/seg; for(let u=knots[domain[0]]; u<=knots[domain[1]]; u+=step){ let x=0,y=0,w=0; for(let i=0;i<=n;i++){ const b=N(i,deg,u)*weights[i]; x+=points[i].x*b; y+=points[i].y*b; w+=b; } out.push({x:x/w,y:y/w}); } return out; }


### PR DESCRIPTION
## Summary
- reset active tool when switching to prevent leftover editing
- add cancellation paths for Catmull-Rom and B-spline tools so first click after confirm starts new curve
- allow right-click or Esc to cancel current curve session

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d5dd1aa288324b0f3349f98864e3d