### PR TITLE
refactor: avoid direct writes to bctx

### DIFF
--- a/index.html
+++ b/index.html
@@ -604,7 +604,7 @@
       function setActiveLayer(i) {
         if (i < 0 || i >= layers.length) return;
         activeLayer = i;
-        engine.ctx = layers[i].getContext("2d", { willReadFrequently: true });
+        // no direct assignment to engine.ctx; getter reflects active layer
         updateLayerList();
         renderLayers();
         engine.requestRepaint();
@@ -731,7 +731,6 @@
         constructor(store, vp) {
           this.store = store;
           this.vp = vp;
-          this.ctx = bctx;
           this.history = new History();
           this.tools = new Map();
           this.current = null;
@@ -748,6 +747,9 @@
             requestAnimationFrame(tick);
           };
           requestAnimationFrame(tick);
+        }
+        get ctx() {
+          return layers[activeLayer].getContext("2d", { willReadFrequently: true });
         }
         setTool(id) {
           if (this.current && this.current.cancel) this.current.cancel();
@@ -1221,10 +1223,10 @@
           onPointerUp() {},
         };
       }
-      function floodFillBctx(x0, y0, rgba, th = 0) {
+      function floodFill(ctx, x0, y0, rgba, th = 0) {
         if (x0 < 0 || y0 < 0 || x0 >= bmp.width || y0 >= bmp.height)
           return null;
-        const img = bctx.getImageData(0, 0, bmp.width, bmp.height),
+        const img = ctx.getImageData(0, 0, bmp.width, bmp.height),
           d = img.data,
           w = bmp.width,
           h = bmp.height,
@@ -1298,9 +1300,9 @@
           w: maxx - minx + 1,
           h: maxy - miny + 1,
         };
-        const before = bctx.getImageData(rect.x, rect.y, rect.w, rect.h);
-        bctx.putImageData(img, 0, 0);
-        const after = bctx.getImageData(rect.x, rect.y, rect.w, rect.h);
+        const before = ctx.getImageData(rect.x, rect.y, rect.w, rect.h);
+        ctx.putImageData(img, 0, 0);
+        const after = ctx.getImageData(rect.x, rect.y, rect.w, rect.h);
         return { rect, before, after };
       }
       function makeBucket(store) {
@@ -1312,7 +1314,8 @@
             const r = parseInt(h.slice(1, 3), 16),
               g = parseInt(h.slice(3, 5), 16),
               b = parseInt(h.slice(5, 7), 16);
-            const p = floodFillBctx(
+            const p = floodFill(
+              ctx,
               Math.floor(ev.img.x),
               Math.floor(ev.img.y),
               [r, g, b, 255],
@@ -1925,7 +1928,7 @@
         }
 
         window.addEventListener("keydown", (e) => {
-          if (e.key === "Enter") finalize(bctx, engine);
+          if (e.key === "Enter") finalize(engine.ctx, engine);
         });
 
         return {
@@ -2077,7 +2080,7 @@
         }
 
         window.addEventListener("keydown", (e) => {
-          if (e.key === "Enter") finalize(bctx, engine);
+          if (e.key === "Enter") finalize(engine.ctx, engine);
         });
 
         return {
@@ -2242,7 +2245,7 @@
         }
 
         window.addEventListener("keydown", (e) => {
-          if (e.key === "Enter") finalize(bctx, engine);
+          if (e.key === "Enter") finalize(engine.ctx, engine);
         });
 
         return {
@@ -2454,12 +2457,12 @@
             if (sel && eng.pointInRect(ev.img, sel.rect)) {
               if (!sel.floatCanvas) {
                 const { x, y, w, h } = sel.rect;
-                const img = bctx.getImageData(x, y, w, h);
+                const img = ctx.getImageData(x, y, w, h);
                 const fc = document.createElement("canvas");
                 fc.width = w;
                 fc.height = h;
                 fc.getContext("2d").putImageData(img, 0, 0);
-                bctx.clearRect(x, y, w, h);
+                ctx.clearRect(x, y, w, h);
                 eng.expandPendingRectByRect(x, y, w, h);
                 sel.floatCanvas = fc;
                 sel.pos = { x, y };
@@ -2514,7 +2517,7 @@
                 neu = { x: sel.pos.x, y: sel.pos.y, w: old.w, h: old.h };
               eng.expandPendingRectByRect(old.x, old.y, old.w, old.h);
               eng.expandPendingRectByRect(neu.x, neu.y, neu.w, neu.h);
-              bctx.drawImage(sel.floatCanvas, neu.x, neu.y);
+              ctx.drawImage(sel.floatCanvas, neu.x, neu.y);
               sel.rect = neu;
               sel.floatCanvas = null;
             } else {
@@ -2553,16 +2556,17 @@
             paddingY = 4;
           const lines = activeEditor.innerText.replace(/\r/g, "").split("\n");
 
-          bctx.save();
-          bctx.font = canvasFont; // Canvasは「xxpx ファミリ」形式のみ有効
-          bctx.fillStyle = color;
-          bctx.textBaseline = "top";
+          const ctx = layers[activeLayer].getContext("2d");
+          ctx.save();
+          ctx.font = canvasFont; // Canvasは「xxpx ファミリ」形式のみ有効
+          ctx.fillStyle = color;
+          ctx.textBaseline = "top";
           let ycur = y + paddingY;
           for (const line of lines) {
-            bctx.fillText(line, x + paddingX, ycur);
+            ctx.fillText(line, x + paddingX, ycur);
             ycur += lineHeightPx;
           }
-          bctx.restore();
+          ctx.restore();
 
           // 履歴（beginStrokeSnapshot は Textツール起動時に呼んでいる前提）
           engine.expandPendingRectByRect(x, y, w, h);
@@ -2894,7 +2898,8 @@
           if (sel.floatCanvas) {
             cctx.drawImage(sel.floatCanvas, 0, 0);
           } else {
-            const img = bctx.getImageData(x, y, w, h);
+            const ctx = layers[activeLayer].getContext("2d");
+            const img = ctx.getImageData(x, y, w, h);
             cctx.putImageData(img, 0, 0);
           }
           srcCanvas = c;
@@ -2924,9 +2929,10 @@
         await doCopy();
         // クリア＆履歴
         const { x, y, w, h } = sel.rect;
-        const before = bctx.getImageData(x, y, w, h);
-        bctx.clearRect(x, y, w, h);
-        const after = bctx.getImageData(x, y, w, h);
+        const ctx = layers[activeLayer].getContext("2d");
+        const before = ctx.getImageData(x, y, w, h);
+        ctx.clearRect(x, y, w, h);
+        const after = ctx.getImageData(x, y, w, h);
         engine.history.pushPatch({ rect: { x, y, w, h }, before, after });
         engine.clearSelection();
         engine.requestRepaint();
@@ -3082,10 +3088,11 @@
           engine.beginStrokeSnapshot();
           const w = canvas.width,
             h = canvas.height;
-          const before = bctx.getImageData(x, y, w, h);
-          bctx.clearRect(x, y, w, h);
-          bctx.drawImage(canvas, x, y);
-          const after = bctx.getImageData(x, y, w, h);
+          const ctx = layers[activeLayer].getContext("2d");
+          const before = ctx.getImageData(x, y, w, h);
+          ctx.clearRect(x, y, w, h);
+          ctx.drawImage(canvas, x, y);
+          const after = ctx.getImageData(x, y, w, h);
           engine.history.pushPatch({ rect: { x, y, w, h }, before, after });
           engine.filterPreview = null;
           engine.requestRepaint();


### PR DESCRIPTION
## Summary
- remove direct assignment to `Engine.ctx` when switching layers
- expose active layer context via `Engine.ctx` getter with `willReadFrequently` option

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a3bc02456c83248fd5f027ad28ff10