### PR TITLE
Add click-toggled freehand drawing tool

### DIFF
--- a/index.html
+++ b/index.html
@@ -341,6 +341,7 @@
             楕円(回転)
           </button>
           <button class="tool" data-tool="freehand" title="H">補間描画</button>
+          <button class="tool" data-tool="freehandClick" title="Shift+H">補間描画(クリック)</button>
           <label class="row badge"
             >塗り <input id="fillOn" type="checkbox" checked
           /></label>
@@ -2525,6 +2526,73 @@
         };
       }
 
+      function makeFreehandClick(store) {
+        let pts = [],
+          drawing = false;
+        return {
+          id: "freehandClick",
+          cursor: "crosshair",
+          previewRect: null,
+          onPointerDown(ctx, ev, eng) {
+            if (!drawing) {
+              drawing = true;
+              pts = [{ ...ev.img }];
+            } else {
+              pts.push({ ...ev.img });
+              const s = store.getState();
+              const sm = catmullRomSpline(pts, 8);
+              ctx.save();
+              ctx.lineWidth = s.brushSize;
+              ctx.strokeStyle = s.primaryColor;
+              ctx.lineCap = "round";
+              ctx.lineJoin = "round";
+              ctx.beginPath();
+              ctx.moveTo(sm[0].x + 0.5, sm[0].y + 0.5);
+              for (let i = 1; i < sm.length; i++)
+                ctx.lineTo(sm[i].x + 0.5, sm[i].y + 0.5);
+              ctx.stroke();
+              ctx.restore();
+              let minX = sm[0].x,
+                maxX = sm[0].x,
+                minY = sm[0].y,
+                maxY = sm[0].y;
+              sm.forEach((p) => {
+                minX = Math.min(minX, p.x);
+                maxX = Math.max(maxX, p.x);
+                minY = Math.min(minY, p.y);
+                maxY = Math.max(maxY, p.y);
+              });
+              eng.expandPendingRectByRect(
+                minX - s.brushSize,
+                minY - s.brushSize,
+                maxX - minX + s.brushSize * 2,
+                maxY - minY + s.brushSize * 2
+              );
+              pts = [];
+              drawing = false;
+            }
+          },
+          onPointerMove(ctx, ev) {
+            if (drawing) pts.push({ ...ev.img });
+          },
+          onPointerUp() {},
+          drawPreview(octx) {
+            if (drawing && pts.length > 1) {
+              const sm = catmullRomSpline(pts, 8);
+              octx.save();
+              octx.lineWidth = store.getState().brushSize;
+              octx.strokeStyle = store.getState().primaryColor;
+              octx.beginPath();
+              octx.moveTo(sm[0].x + 0.5, sm[0].y + 0.5);
+              for (let i = 1; i < sm.length; i++)
+                octx.lineTo(sm[i].x + 0.5, sm[i].y + 0.5);
+              octx.stroke();
+              octx.restore();
+            }
+          },
+        };
+      }
+
       function makeSelectRect() {
         let dragging = false,
           moving = false,
@@ -2874,6 +2942,7 @@
       engine.register(makeNURBS(store));
       engine.register(makeEllipse2(store));
       engine.register(makeFreehand(store));
+      engine.register(makeFreehandClick(store));
       engine.register(makeTextTool(store));
       selectTool("pencil");
 


### PR DESCRIPTION
## Summary
- add UI button and tool registration for click-based freehand drawing
- implement `makeFreehandClick` for click-to-start/stop freehand strokes with preview

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a700c1eff48324b4e554e38a65feac