### PR TITLE
feat: add simple event bus and integrate state store

### DIFF
--- a/app.js
+++ b/app.js
@@ -6,6 +6,7 @@ import { initIO, initDocument, openImageFile, triggerSave, doCopy, doCut, handle
 import { DOMManager } from './managers/dom-manager.js';
 import { Viewport } from './core/viewport.js';
 import { createStore, defaultState } from './core/store.js';
+import { EventBus } from './core/event-bus.js';
 import { AdjustmentManager } from './managers/adjustment-manager.js';
 import { cancelTextEditing, getActiveEditor } from './managers/text-editor.js';
 
@@ -13,9 +14,10 @@ export class PaintApp {
   constructor() {
     this.domManager = new DOMManager();
     window.getCanvasArea = () => this.domManager.getCanvasArea();
-    this.store = createStore(defaultState);
+    this.eventBus = new EventBus();
+    this.store = createStore(defaultState, this.eventBus);
     this.viewport = new Viewport();
-    this.engine = new Engine(this.store, this.viewport);
+    this.engine = new Engine(this.store, this.viewport, this.eventBus);
     this.adjustmentManager = null;
     this.init();
   }

--- a/core/event-bus.js
+++ b/core/event-bus.js
@@ -1,0 +1,31 @@
+export class EventBus {
+  constructor() {
+    this.events = new Map();
+  }
+
+  on(event, handler) {
+    if (!this.events.has(event)) {
+      this.events.set(event, new Set());
+    }
+    this.events.get(event).add(handler);
+    return () => this.off(event, handler);
+  }
+
+  off(event, handler) {
+    const handlers = this.events.get(event);
+    if (handlers) handlers.delete(handler);
+  }
+
+  emit(event, payload) {
+    const handlers = this.events.get(event);
+    if (handlers) {
+      handlers.forEach((h) => {
+        try {
+          h(payload);
+        } catch (err) {
+          console.error('EventBus handler error for', event, err);
+        }
+      });
+    }
+  }
+}

--- a/engine.js
+++ b/engine.js
@@ -27,9 +27,10 @@ class History {
 
 /* ===== engine ===== */
 export class Engine {
-  constructor(store, vp) {
+  constructor(store, vp, eventBus) {
     this.store = store;
     this.vp = vp;
+    this.eventBus = eventBus;
     this.history = new History();
     this.tools = new Map();
     this.current = null;


### PR DESCRIPTION
## Summary
- introduce lightweight EventBus for decoupled communication
- refactor store into class emitting `store:updated` events
- wire PaintApp and Engine to share the EventBus

## Testing
- `npm test` *(fails: ENOENT, package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1088a75f083249a6398bb9fb39c80