### PR TITLE
refactor: eliminate window globals

### DIFF
--- a/index.html
+++ b/index.html
@@ -153,21 +153,13 @@
   <script src="src/tools/brush.js"></script>
   <script src="src/tools/eraser.js"></script>
   <script src="src/tools/eraserClick.js"></script>
-  <script src="src/tools/eyedropper.js"></script>
-  <script src="src/tools/bucket.js"></script>
-  <script src="src/tools/shape.js"></script>
   <script src="src/tools/quadratic.js"></script>
   <script src="src/tools/cubic.js"></script>
   <script src="src/tools/arc.js"></script>
   <script src="src/tools/sector.js"></script>
-  <script src="src/tools/catmull.js"></script>
-  <script src="src/tools/bspline.js"></script>
-  <script src="src/tools/nurbs.js"></script>
   <script src="src/tools/ellipse2.js"></script>
   <script src="src/tools/freehand.js"></script>
   <script src="src/tools/freehandClick.js"></script>
-  <script src="src/tools/textTool.js"></script>
-
   <script type="module" src="src/main.js"></script>
 </body>
 

--- a/src/app.js
+++ b/src/app.js
@@ -9,6 +9,13 @@ import { createStore, defaultState } from './core/store.js';
 import { EventBus } from './core/event-bus.js';
 import { AdjustmentManager } from './managers/adjustment-manager.js';
 import { cancelTextEditing, getActiveEditor } from './managers/text-editor.js';
+import { makeEyedropper } from './tools/eyedropper.js';
+import { makeBucket } from './tools/bucket.js';
+import { makeShape } from './tools/shape.js';
+import { makeTextTool } from './tools/textTool.js';
+import { makeCatmull } from './tools/catmull.js';
+import { makeBSpline } from './tools/bspline.js';
+import { makeNURBS } from './tools/nurbs.js';
 
 export class PaintApp {
   constructor() {

--- a/src/engine.js
+++ b/src/engine.js
@@ -3,6 +3,7 @@ import { clamp, dpr, resizeCanvasToDisplaySize } from './utils/helpers.js';
 import { cancelTextEditing, getActiveEditor } from './managers/text-editor.js';
 import { openImageFile } from './io.js';
 import { updateStatus, updateZoom } from './gui/statusbar.js';
+import { selectTool } from './main.js';
 
 /* ===== history ===== */
 class History {

--- a/src/main.js
+++ b/src/main.js
@@ -1,23 +1,30 @@
 import { PaintApp } from './app.js';
 import { toHex } from './utils/helpers.js';
 import { drawEllipsePath, floodFill } from './utils/drawing.js';
-import { cancelTextEditing as cancelTextEdit, createTextEditor, isTextEditing } from './managers/text-editor.js';
+import {
+  cancelTextEditing as cancelTextEdit,
+  createTextEditor as createTextEditorImpl,
+  isTextEditing,
+} from './managers/text-editor.js';
 import { layers, activeLayer, bmp } from './layer.js';
 
 const app = new PaintApp();
 
-window.toHex = toHex;
-window.selectTool = (id) => app.selectTool(id);
-window.cancelTextEditing = (commit = false) => cancelTextEdit(commit, layers, activeLayer, app.engine);
-window.createTextEditor = (x, y, store) =>
-  createTextEditor(x, y, store, app.engine, app.domManager.elements.editorLayer, layers, activeLayer);
-window.isTextEditing = isTextEditing;
-window.floodFill = floodFill;
-window.drawEllipsePath = drawEllipsePath;
-window.engine = app.engine;
-window.bmp = bmp;
-window.layers = layers;
-window.activeLayer = activeLayer;
+export { toHex, drawEllipsePath, floodFill, layers, activeLayer, bmp, isTextEditing };
+export const engine = app.engine;
+export const selectTool = (id) => app.selectTool(id);
+export const cancelTextEditing = (commit = false) =>
+  cancelTextEdit(commit, layers, activeLayer, app.engine);
+export const createTextEditor = (x, y, store) =>
+  createTextEditorImpl(
+    x,
+    y,
+    store,
+    app.engine,
+    app.domManager.elements.editorLayer,
+    layers,
+    activeLayer,
+  );
 
 window.addEventListener('load', () => app.boot());
 
@@ -25,9 +32,9 @@ document.addEventListener(
   'pointerdown',
   (e) => {
     if (isTextEditing() && !e.target?.closest?.('.text-editor')) {
-      window.cancelTextEditing(true);
+      cancelTextEditing(true);
       app.engine.requestRepaint();
     }
   },
-  { capture: true }
+  { capture: true },
 );

--- a/src/tools/bspline.js
+++ b/src/tools/bspline.js
@@ -1,116 +1,119 @@
-      function makeBSpline(store) {
-        let pts = [],
-          fresh = true,
-          hover = null;
-        const reset = () => {
-          pts = [];
-          fresh = true;
-          hover = null;
-        };
+import { bspline } from '../spline.js';
+import { engine } from '../main.js';
 
-        function finalize(ctx, eng) {
-          if (pts.length < 4) {
-            reset();
-            eng.requestRepaint();
-            return;
-          }
-          const s = store.getState();
-          const cr = bspline(pts);
-          ctx.save();
-          ctx.lineWidth = s.brushSize;
-          ctx.strokeStyle = s.primaryColor;
-          ctx.beginPath();
-          ctx.moveTo(cr[0].x + 0.5, cr[0].y + 0.5);
-          for (let i = 1; i < cr.length; i++) {
-            ctx.lineTo(cr[i].x + 0.5, cr[i].y + 0.5);
-          }
-          ctx.stroke();
-          ctx.restore();
+export function makeBSpline(store) {
+  let pts = [],
+    fresh = true,
+    hover = null;
+  const reset = () => {
+    pts = [];
+    fresh = true;
+    hover = null;
+  };
 
-          let minX = cr[0].x,
-            maxX = cr[0].x,
-            minY = cr[0].y,
-            maxY = cr[0].y;
-          cr.forEach((p) => {
-            minX = Math.min(minX, p.x);
-            maxX = Math.max(maxX, p.x);
-            minY = Math.min(minY, p.y);
-            maxY = Math.max(maxY, p.y);
-          });
-          eng.expandPendingRectByRect(
-            minX - s.brushSize,
-            minY - s.brushSize,
-            maxX - minX + s.brushSize * 2,
-            maxY - minY + s.brushSize * 2
-          );
-          eng.finishStrokeToHistory();
-          eng.requestRepaint();
-          reset();
-        }
+  function finalize(ctx, eng) {
+    if (pts.length < 4) {
+      reset();
+      eng.requestRepaint();
+      return;
+    }
+    const s = store.getState();
+    const cr = bspline(pts);
+    ctx.save();
+    ctx.lineWidth = s.brushSize;
+    ctx.strokeStyle = s.primaryColor;
+    ctx.beginPath();
+    ctx.moveTo(cr[0].x + 0.5, cr[0].y + 0.5);
+    for (let i = 1; i < cr.length; i++) {
+      ctx.lineTo(cr[i].x + 0.5, cr[i].y + 0.5);
+    }
+    ctx.stroke();
+    ctx.restore();
 
-        return {
-          id: "bspline",
-          cursor: "crosshair",
-          previewRect: null,
-          onEnter(ctx, eng) {
-            finalize(ctx, eng);
-          },
-          cancel() {
-            reset();
-            engine.requestRepaint();
-          },
-          onPointerDown(ctx, ev, eng) {
-            if (ev.button === 0 && ev.detail === 2) {
-              if (pts.length === 0) eng.beginStrokeSnapshot();
-              pts.push({ ...ev.img });
-              finalize(ctx, eng);
-              return;
-            }
-            if (fresh) {
-              pts = [];
-              fresh = false;
-            }
-            pts.push({ ...ev.img });
-          },
-          onPointerMove(ctx, ev) {
-            hover = { ...ev.img };
-          },
-          onPointerUp() {},
-          drawPreview(octx) {
-            const s = store.getState();
-            octx.save();
-            octx.lineWidth = s.brushSize;
-            octx.strokeStyle = s.primaryColor;
+    let minX = cr[0].x,
+      maxX = cr[0].x,
+      minY = cr[0].y,
+      maxY = cr[0].y;
+    cr.forEach((p) => {
+      minX = Math.min(minX, p.x);
+      maxX = Math.max(maxX, p.x);
+      minY = Math.min(minY, p.y);
+      maxY = Math.max(maxY, p.y);
+    });
+    eng.expandPendingRectByRect(
+      minX - s.brushSize,
+      minY - s.brushSize,
+      maxX - minX + s.brushSize * 2,
+      maxY - minY + s.brushSize * 2,
+    );
+    eng.finishStrokeToHistory();
+    eng.requestRepaint();
+    reset();
+  }
 
-            const need = 4;
-            if (pts.length >= need) {
-              const src = hover ? [...pts, hover] : pts;
-              const cr = bspline(src);
-              if (cr.length >= 2) {
-                octx.beginPath();
-                octx.moveTo(cr[0].x + 0.5, cr[0].y + 0.5);
-                for (let i = 1; i < cr.length; i++) {
-                  octx.lineTo(cr[i].x + 0.5, cr[i].y + 0.5);
-                }
-                octx.stroke();
-              }
-            } else if (pts.length >= 1) {
-              const poly = hover ? [...pts, hover] : pts;
-              if (poly.length >= 2) {
-                octx.beginPath();
-                octx.moveTo(poly[0].x + 0.5, poly[0].y + 0.5);
-                for (let i = 1; i < poly.length; i++) {
-                  octx.lineTo(poly[i].x + 0.5, poly[i].y + 0.5);
-                }
-                octx.stroke();
-              } else if (poly.length === 1 && hover) {
-                octx.beginPath();
-                octx.moveTo(poly[0].x + 0.5, poly[0].y + 0.5);
-                octx.lineTo(hover.x + 0.5, hover.y + 0.5);
-                octx.stroke();
-              }
-            }
-            octx.restore();
-          },
-        };
+  return {
+    id: 'bspline',
+    cursor: 'crosshair',
+    previewRect: null,
+    onEnter(ctx, eng) {
+      finalize(ctx, eng);
+    },
+    cancel() {
+      reset();
+      engine.requestRepaint();
+    },
+    onPointerDown(ctx, ev, eng) {
+      if (ev.button === 0 && ev.detail === 2) {
+        if (pts.length === 0) eng.beginStrokeSnapshot();
+        pts.push({ ...ev.img });
+        finalize(ctx, eng);
+        return;
       }
+      if (fresh) {
+        pts = [];
+        fresh = false;
+      }
+      pts.push({ ...ev.img });
+    },
+    onPointerMove(ctx, ev) {
+      hover = { ...ev.img };
+    },
+    onPointerUp() {},
+    drawPreview(octx) {
+      const s = store.getState();
+      octx.save();
+      octx.lineWidth = s.brushSize;
+      octx.strokeStyle = s.primaryColor;
+
+      const need = 4;
+      if (pts.length >= need) {
+        const src = hover ? [...pts, hover] : pts;
+        const cr = bspline(src);
+        if (cr.length >= 2) {
+          octx.beginPath();
+          octx.moveTo(cr[0].x + 0.5, cr[0].y + 0.5);
+          for (let i = 1; i < cr.length; i++) {
+            octx.lineTo(cr[i].x + 0.5, cr[i].y + 0.5);
+          }
+          octx.stroke();
+        }
+      } else if (pts.length >= 1) {
+        const poly = hover ? [...pts, hover] : pts;
+        if (poly.length >= 2) {
+          octx.beginPath();
+          octx.moveTo(poly[0].x + 0.5, poly[0].y + 0.5);
+          for (let i = 1; i < poly.length; i++) {
+            octx.lineTo(poly[i].x + 0.5, poly[i].y + 0.5);
+          }
+          octx.stroke();
+        } else if (poly.length === 1 && hover) {
+          octx.beginPath();
+          octx.moveTo(poly[0].x + 0.5, poly[0].y + 0.5);
+          octx.lineTo(hover.x + 0.5, hover.y + 0.5);
+          octx.stroke();
+        }
+      }
+      octx.restore();
+    },
+  };
+}

--- a/src/tools/bucket.js
+++ b/src/tools/bucket.js
@@ -1,22 +1,24 @@
-      function makeBucket(store) {
-        return {
-          id: "bucket",
-          cursor: "pointer",
-          onPointerDown(ctx, ev, eng) {
-            const h = store.getState().primaryColor;
-            const r = parseInt(h.slice(1, 3), 16),
-              g = parseInt(h.slice(3, 5), 16),
-              b = parseInt(h.slice(5, 7), 16);
-            const p = floodFill(
-              ctx,
-              Math.floor(ev.img.x),
-              Math.floor(ev.img.y),
-              [r, g, b, 255],
-              16
-            );
-            if (p) eng.history.pushPatch(p);
-          },
-          onPointerMove() {},
-          onPointerUp() {},
-        };
-      }
+import { floodFill } from '../utils/drawing.js';
+
+export function makeBucket(store) {
+  return {
+    id: 'bucket',
+    cursor: 'pointer',
+    onPointerDown(ctx, ev, eng) {
+      const h = store.getState().primaryColor;
+      const r = parseInt(h.slice(1, 3), 16),
+        g = parseInt(h.slice(3, 5), 16),
+        b = parseInt(h.slice(5, 7), 16);
+      const p = floodFill(
+        ctx,
+        Math.floor(ev.img.x),
+        Math.floor(ev.img.y),
+        [r, g, b, 255],
+        16,
+      );
+      if (p) eng.history.pushPatch(p);
+    },
+    onPointerMove() {},
+    onPointerUp() {},
+  };
+}

--- a/src/tools/catmull.js
+++ b/src/tools/catmull.js
@@ -1,91 +1,92 @@
-      function makeCatmull(store) {
-        let pts = [],
-          fresh = true;
-        const reset = () => {
-          pts = [];
-          fresh = true;
-        };
-        function finalize(ctx, eng) {
-          if (pts.length < 4) {
-            reset();
-            eng.requestRepaint();
-            return;
-          }
-          const s = store.getState();
-          const cr = catmullRomSpline(pts);
-          ctx.save();
-          ctx.lineWidth = s.brushSize;
-          ctx.strokeStyle = s.primaryColor;
-          ctx.beginPath();
-          ctx.moveTo(cr[0].x + 0.5, cr[0].y + 0.5);
-          for (let i = 1; i < cr.length; i++)
-            ctx.lineTo(cr[i].x + 0.5, cr[i].y + 0.5);
-          ctx.stroke();
-          ctx.restore();
-          let minX = cr[0].x,
-            maxX = cr[0].x,
-            minY = cr[0].y,
-            maxY = cr[0].y;
-          cr.forEach((p) => {
-            minX = Math.min(minX, p.x);
-            maxX = Math.max(maxX, p.x);
-            minY = Math.min(minY, p.y);
-            maxY = Math.max(maxY, p.y);
-          });
-          eng.expandPendingRectByRect(
-            minX - s.brushSize,
-            minY - s.brushSize,
-            maxX - minX + s.brushSize * 2,
-            maxY - minY + s.brushSize * 2
-          );
-          eng.finishStrokeToHistory();
-          eng.requestRepaint();
-          reset();
+import { catmullRomSpline } from '../spline.js';
+import { bctx } from '../layer.js';
+import { engine } from '../main.js';
+
+export function makeCatmull(store) {
+  let pts = [],
+    fresh = true;
+  const reset = () => {
+    pts = [];
+    fresh = true;
+  };
+  function finalize(ctx, eng) {
+    if (pts.length < 4) {
+      reset();
+      eng.requestRepaint();
+      return;
+    }
+    const s = store.getState();
+    const cr = catmullRomSpline(pts);
+    ctx.save();
+    ctx.lineWidth = s.brushSize;
+    ctx.strokeStyle = s.primaryColor;
+    ctx.beginPath();
+    ctx.moveTo(cr[0].x + 0.5, cr[0].y + 0.5);
+    for (let i = 1; i < cr.length; i++)
+      ctx.lineTo(cr[i].x + 0.5, cr[i].y + 0.5);
+    ctx.stroke();
+    ctx.restore();
+    let minX = cr[0].x,
+      maxX = cr[0].x,
+      minY = cr[0].y,
+      maxY = cr[0].y;
+    cr.forEach((p) => {
+      minX = Math.min(minX, p.x);
+      maxX = Math.max(maxX, p.x);
+      minY = Math.min(minY, p.y);
+      maxY = Math.max(maxY, p.y);
+    });
+    eng.expandPendingRectByRect(
+      minX - s.brushSize,
+      minY - s.brushSize,
+      maxX - minX + s.brushSize * 2,
+      maxY - minY + s.brushSize * 2,
+    );
+    eng.finishStrokeToHistory();
+    eng.requestRepaint();
+    reset();
+  }
+  window.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter') finalize(bctx, engine);
+  });
+  return {
+    id: 'catmull',
+    cursor: 'crosshair',
+    previewRect: null,
+    cancel() {
+      reset();
+      engine.requestRepaint();
+    },
+    onPointerDown(ctx, ev, eng) {
+      console.log(ev);
+      // Double click: add point then finalize
+      if (ev.button === 0 && ev.detail === 2) {
+        if (pts.length === 0) eng.beginStrokeSnapshot();
+        pts.push({ ...ev.img });
+        finalize(ctx, eng);
+        return;
         }
-        window.addEventListener("keydown", (e) => {
-
-          if (e.key === "Enter") finalize(bctx, engine);
-        });
-        return {
-          id: "catmull",
-          cursor: "crosshair",
-          previewRect: null,
-          cancel() {
-            reset();
-            engine.requestRepaint();
-          },
-          onPointerDown(ctx, ev, eng) {
-
-            console.log(ev);
-            // ★ ダブルクリック：このクリック地点を点列に追加してから確定
-            if (ev.button === 0 && ev.detail === 2) {
-              if (pts.length === 0) eng.beginStrokeSnapshot(); // 初回クリックと同等に扱う
-              pts.push({ ...ev.img }); // 終点として追加
-              finalize(ctx, eng); // Enter相当
-              return;
-            }
-            // ふつうのクリック
-            if (fresh) {
-              pts = [];
-              fresh = false;
-            }
-            pts.push({ ...ev.img });
-          },
-          onPointerMove() { },
-          onPointerUp() { },
-          drawPreview(octx) {
-            if (pts.length > 1) {
-              const cr = catmullRomSpline(pts);
-              octx.save();
-              octx.lineWidth = store.getState().brushSize;
-              octx.strokeStyle = store.getState().primaryColor;
-              octx.beginPath();
-              octx.moveTo(cr[0].x + 0.5, cr[0].y + 0.5);
-              for (let i = 1; i < cr.length; i++)
-                octx.lineTo(cr[i].x + 0.5, cr[i].y + 0.5);
-              octx.stroke();
-              octx.restore();
-            }
-          },
-        };
+      if (fresh) {
+        pts = [];
+        fresh = false;
       }
+      pts.push({ ...ev.img });
+    },
+    onPointerMove() {},
+    onPointerUp() {},
+    drawPreview(octx) {
+      if (pts.length > 1) {
+        const cr = catmullRomSpline(pts);
+        octx.save();
+        octx.lineWidth = store.getState().brushSize;
+        octx.strokeStyle = store.getState().primaryColor;
+        octx.beginPath();
+        octx.moveTo(cr[0].x + 0.5, cr[0].y + 0.5);
+        for (let i = 1; i < cr.length; i++)
+          octx.lineTo(cr[i].x + 0.5, cr[i].y + 0.5);
+        octx.stroke();
+        octx.restore();
+      }
+    },
+  };
+}

--- a/src/tools/eyedropper.js
+++ b/src/tools/eyedropper.js
@@ -1,15 +1,18 @@
-      function makeEyedropper(store) {
-        return {
-          id: "eyedropper",
-          cursor: "copy",
-          onPointerDown(ctx, ev) {
-            const x = Math.floor(ev.img.x),
-              y = Math.floor(ev.img.y);
-            if (x < 0 || y < 0 || x >= bmp.width || y >= bmp.height) return;
-            const { data } = bctx.getImageData(x, y, 1, 1);
-            store.set({ primaryColor: toHex(data[0], data[1], data[2]) });
-          },
-          onPointerMove() {},
-          onPointerUp() {},
-        };
-      }
+import { bmp, bctx } from '../layer.js';
+import { toHex } from '../utils/helpers.js';
+
+export function makeEyedropper(store) {
+  return {
+    id: 'eyedropper',
+    cursor: 'copy',
+    onPointerDown(ctx, ev) {
+      const x = Math.floor(ev.img.x),
+        y = Math.floor(ev.img.y);
+      if (x < 0 || y < 0 || x >= bmp.width || y >= bmp.height) return;
+      const { data } = bctx.getImageData(x, y, 1, 1);
+      store.set({ primaryColor: toHex(data[0], data[1], data[2]) });
+    },
+    onPointerMove() {},
+    onPointerUp() {},
+  };
+}

--- a/src/tools/nurbs.js
+++ b/src/tools/nurbs.js
@@ -1,122 +1,127 @@
-      function makeNURBS(store) {
-        let pts = [],
-          ws = [],
-          hover = null;
+import { nurbs } from '../spline.js';
+import { engine } from '../main.js';
 
-        function finalize(ctx, eng) {
-          if (pts.length < 4) return;
-          const s = store.getState();
-          const cr = nurbs(pts, ws);
-          if (!cr.length) {
-            pts = [];
-            ws = [];
-            hover = null;
-            nurbsWeightEl.value = "1";
-            eng.requestRepaint();
-            return;
-          }
-          ctx.save();
-          ctx.lineWidth = s.brushSize;
-          ctx.strokeStyle = s.primaryColor;
-          ctx.beginPath();
-          ctx.moveTo(cr[0].x + 0.5, cr[0].y + 0.5);
+const nurbsWeightEl = document.getElementById('nurbsWeight');
+
+export function makeNURBS(store) {
+  let pts = [],
+    ws = [],
+    hover = null;
+
+  function finalize(ctx, eng) {
+    if (pts.length < 4) return;
+    const s = store.getState();
+    const cr = nurbs(pts, ws);
+    if (!cr.length) {
+      pts = [];
+      ws = [];
+      hover = null;
+      nurbsWeightEl.value = '1';
+      eng.requestRepaint();
+      return;
+    }
+    ctx.save();
+    ctx.lineWidth = s.brushSize;
+    ctx.strokeStyle = s.primaryColor;
+    ctx.beginPath();
+    ctx.moveTo(cr[0].x + 0.5, cr[0].y + 0.5);
+    for (let i = 1; i < cr.length; i++) {
+      const p = cr[i];
+      if (!Number.isFinite(p.x) || !Number.isFinite(p.y)) continue;
+      ctx.lineTo(p.x + 0.5, p.y + 0.5);
+    }
+    ctx.stroke();
+    ctx.restore();
+
+    let minX = cr[0].x,
+      maxX = cr[0].x,
+      minY = cr[0].y,
+      maxY = cr[0].y;
+    cr.forEach((p) => {
+      minX = Math.min(minX, p.x);
+      maxX = Math.max(maxX, p.x);
+      minY = Math.min(minY, p.y);
+      maxY = Math.max(maxY, p.y);
+    });
+    eng.expandPendingRectByRect(
+      minX - s.brushSize,
+      minY - s.brushSize,
+      maxX - minX + s.brushSize * 2,
+      maxY - minY + s.brushSize * 2,
+    );
+    eng.finishStrokeToHistory();
+    eng.requestRepaint();
+
+    pts = [];
+    ws = [];
+    hover = null;
+    nurbsWeightEl.value = '1';
+  }
+
+  window.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter') finalize(engine.ctx, engine);
+  });
+
+  return {
+    id: 'nurbs',
+    cursor: 'crosshair',
+    previewRect: null,
+    onPointerDown(ctx, ev, eng) {
+      if (ev.button === 0 && ev.detail === 2) {
+        if (pts.length === 0) eng.beginStrokeSnapshot();
+        pts.push({ ...ev.img });
+        const w = parseFloat(nurbsWeightEl.value);
+        ws.push(Number.isFinite(w) && w > 0 ? w : 1);
+        finalize(ctx, eng);
+        return;
+      }
+      if (pts.length === 0) eng.beginStrokeSnapshot();
+      pts.push({ ...ev.img });
+      const w = parseFloat(nurbsWeightEl.value);
+      ws.push(Number.isFinite(w) && w > 0 ? w : 1);
+    },
+    onPointerMove(ctx, ev) {
+      hover = { ...ev.img };
+    },
+    onPointerUp() {},
+    drawPreview(octx) {
+      const s = store.getState();
+      octx.save();
+      octx.lineWidth = s.brushSize;
+      octx.strokeStyle = s.primaryColor;
+
+      const need = 4;
+      if (pts.length >= need) {
+        const srcPts = hover ? [...pts, hover] : pts;
+        const srcWs = hover ? [...ws, 1] : ws;
+        const cr = nurbs(srcPts, srcWs);
+        if (cr.length >= 2) {
+          octx.beginPath();
+          octx.moveTo(cr[0].x + 0.5, cr[0].y + 0.5);
           for (let i = 1; i < cr.length; i++) {
             const p = cr[i];
             if (!Number.isFinite(p.x) || !Number.isFinite(p.y)) continue;
-            ctx.lineTo(p.x + 0.5, p.y + 0.5);
+            octx.lineTo(p.x + 0.5, p.y + 0.5);
           }
-          ctx.stroke();
-          ctx.restore();
-
-          let minX = cr[0].x,
-            maxX = cr[0].x,
-            minY = cr[0].y,
-            maxY = cr[0].y;
-          cr.forEach((p) => {
-            minX = Math.min(minX, p.x);
-            maxX = Math.max(maxX, p.x);
-            minY = Math.min(minY, p.y);
-            maxY = Math.max(maxY, p.y);
-          });
-          eng.expandPendingRectByRect(
-            minX - s.brushSize,
-            minY - s.brushSize,
-            maxX - minX + s.brushSize * 2,
-            maxY - minY + s.brushSize * 2
-          );
-          eng.finishStrokeToHistory();
-          eng.requestRepaint();
-
-          pts = [];
-          ws = [];
-          hover = null;
-          nurbsWeightEl.value = "1";
+          octx.stroke();
         }
-
-        window.addEventListener("keydown", (e) => {
-          if (e.key === "Enter") finalize(engine.ctx, engine);
-        });
-
-        return {
-          id: "nurbs",
-          cursor: "crosshair",
-          previewRect: null,
-          onPointerDown(ctx, ev, eng) {
-            if (ev.button === 0 && ev.detail === 2) {
-              if (pts.length === 0) eng.beginStrokeSnapshot();
-              pts.push({ ...ev.img });
-              const w = parseFloat(nurbsWeightEl.value);
-              ws.push(Number.isFinite(w) && w > 0 ? w : 1);
-              finalize(ctx, eng);
-              return;
-            }
-            if (pts.length === 0) eng.beginStrokeSnapshot();
-            pts.push({ ...ev.img });
-            const w = parseFloat(nurbsWeightEl.value);
-            ws.push(Number.isFinite(w) && w > 0 ? w : 1);
-          },
-          onPointerMove(ctx, ev) {
-            hover = { ...ev.img };
-          },
-          onPointerUp() {},
-          drawPreview(octx) {
-            const s = store.getState();
-            octx.save();
-            octx.lineWidth = s.brushSize;
-            octx.strokeStyle = s.primaryColor;
-
-            const need = 4;
-            if (pts.length >= need) {
-              const srcPts = hover ? [...pts, hover] : pts;
-              const srcWs = hover ? [...ws, 1] : ws;
-              const cr = nurbs(srcPts, srcWs);
-              if (cr.length >= 2) {
-                octx.beginPath();
-                octx.moveTo(cr[0].x + 0.5, cr[0].y + 0.5);
-                for (let i = 1; i < cr.length; i++) {
-                  const p = cr[i];
-                  if (!Number.isFinite(p.x) || !Number.isFinite(p.y)) continue;
-                  octx.lineTo(p.x + 0.5, p.y + 0.5);
-                }
-                octx.stroke();
-              }
-            } else if (pts.length >= 1) {
-              const poly = hover ? [...pts, hover] : pts;
-              if (poly.length >= 2) {
-                octx.beginPath();
-                octx.moveTo(poly[0].x + 0.5, poly[0].y + 0.5);
-                for (let i = 1; i < poly.length; i++) {
-                  octx.lineTo(poly[i].x + 0.5, poly[i].y + 0.5);
-                }
-                octx.stroke();
-              } else if (poly.length === 1 && hover) {
-                octx.beginPath();
-                octx.moveTo(poly[0].x + 0.5, poly[0].y + 0.5);
-                octx.lineTo(hover.x + 0.5, hover.y + 0.5);
-                octx.stroke();
-              }
-            }
-            octx.restore();
-          },
-        };
+      } else if (pts.length >= 1) {
+        const poly = hover ? [...pts, hover] : pts;
+        if (poly.length >= 2) {
+          octx.beginPath();
+          octx.moveTo(poly[0].x + 0.5, poly[0].y + 0.5);
+          for (let i = 1; i < poly.length; i++) {
+            octx.lineTo(poly[i].x + 0.5, poly[i].y + 0.5);
+          }
+          octx.stroke();
+        } else if (poly.length === 1 && hover) {
+          octx.beginPath();
+          octx.moveTo(poly[0].x + 0.5, poly[0].y + 0.5);
+          octx.lineTo(hover.x + 0.5, hover.y + 0.5);
+          octx.stroke();
+        }
       }
+      octx.restore();
+    },
+  };
+}

--- a/src/tools/shape.js
+++ b/src/tools/shape.js
@@ -1,114 +1,116 @@
-      function makeShape(kind, store) {
-        let drawing = false,
-          start = null,
-          lastPreview = null;
-        return {
-          id: kind,
-          cursor: "crosshair",
-          previewRect: null,
-          onPointerDown(ctx, ev, eng) {
-            eng.clearSelection();
-            drawing = true;
-            start = { ...ev.img };
-            lastPreview = null;
-          },
-          onPointerMove(ctx, ev, eng) {
-            if (!drawing) return;
-            const cur = { ...ev.img };
-            const s = store.getState();
-            const x1 = Math.min(start.x, cur.x),
-              y1 = Math.min(start.y, cur.y);
-            let w = Math.max(1, Math.abs(cur.x - start.x)),
-              h = Math.max(1, Math.abs(cur.y - start.y));
-            if (ev.shift) {
-              if (kind === "line") {
-                const dx = cur.x - start.x,
-                  dy = cur.y - start.y;
-                const a = Math.atan2(dy, dx);
-                const ang = Math.round(a / (Math.PI / 4)) * (Math.PI / 4);
-                const len = Math.hypot(dx, dy);
-                cur.x = start.x + Math.cos(ang) * len;
-                cur.y = start.y + Math.sin(ang) * len;
-              } else {
-                const m = Math.max(w, h);
-                w = h = m;
-              }
-            }
-            this.previewRect =
-              kind === "line"
-                ? {
-                    x: Math.min(start.x, cur.x),
-                    y: Math.min(start.y, cur.y),
-                    w: Math.abs(cur.x - start.x),
-                    h: Math.abs(cur.y - start.y),
-                  }
-                : {
-                    x: Math.floor(x1),
-                    y: Math.floor(y1),
-                    w: Math.floor(w),
-                    h: Math.floor(h),
-                  };
-            lastPreview = { start, cur, shift: ev.shift, state: { ...s } };
-          },
-          onPointerUp(ctx, ev, eng) {
-            if (!drawing) return;
-            drawing = false;
-            if (!lastPreview) {
-              this.previewRect = null;
-              return;
-            }
-            const { start: s, cur, state } = lastPreview;
-            const strokeColor = state.primaryColor,
-              fillColor = state.secondaryColor;
-            const lineWidth = state.brushSize,
-              fillOn = state.fillOn;
-            ctx.save();
-            ctx.imageSmoothingEnabled = store.getState().antialias;
-            ctx.lineWidth = lineWidth;
-            ctx.strokeStyle = strokeColor;
-            ctx.fillStyle = fillColor;
-            if (kind === "line") {
-              ctx.beginPath();
-              ctx.moveTo(s.x + 0.5, s.y + 0.5);
-              ctx.lineTo(cur.x + 0.5, cur.y + 0.5);
-              ctx.stroke();
-              eng.expandPendingRectByRect(
-                Math.min(s.x, cur.x) - lineWidth,
-                Math.min(s.y, cur.y) - lineWidth,
-                Math.abs(cur.x - s.x) + lineWidth * 2,
-                Math.abs(cur.y - s.y) + lineWidth * 2
-              );
-            } else if (kind === "rect") {
-              const x = Math.min(s.x, cur.x),
-                y = Math.min(s.y, cur.y),
-                w = Math.abs(cur.x - s.x),
-                h = Math.abs(cur.y - s.y);
-              if (fillOn) ctx.fillRect(x, y, w, h);
-              ctx.strokeRect(x + 0.5, y + 0.5, w, h);
-              eng.expandPendingRectByRect(
-                x - lineWidth,
-                y - lineWidth,
-                w + lineWidth * 2,
-                h + lineWidth * 2
-              );
-            } else if (kind === "ellipse") {
-              const cx = (s.x + cur.x) / 2,
-                cy = (s.y + cur.y) / 2,
-                rx = Math.abs(cur.x - s.x) / 2,
-                ry = Math.abs(cur.y - s.y) / 2;
-              ctx.beginPath();
-              drawEllipsePath(ctx, cx, cy, rx, ry);
-              if (fillOn) ctx.fill();
-              ctx.stroke();
-              eng.expandPendingRectByRect(
-                cx - rx - lineWidth,
-                cy - ry - lineWidth,
-                rx * 2 + lineWidth * 2,
-                ry * 2 + lineWidth * 2
-              );
-            }
-            ctx.restore();
-            this.previewRect = null;
-          },
-        };
+import { drawEllipsePath } from '../utils/drawing.js';
+
+export function makeShape(kind, store) {
+  let drawing = false,
+    start = null,
+    lastPreview = null;
+  return {
+    id: kind,
+    cursor: 'crosshair',
+    previewRect: null,
+    onPointerDown(ctx, ev, eng) {
+      eng.clearSelection();
+      drawing = true;
+      start = { ...ev.img };
+      lastPreview = null;
+    },
+    onPointerMove(ctx, ev, eng) {
+      if (!drawing) return;
+      const cur = { ...ev.img };
+      const s = store.getState();
+      const x1 = Math.min(start.x, cur.x),
+        y1 = Math.min(start.y, cur.y);
+      let w = Math.max(1, Math.abs(cur.x - start.x)),
+        h = Math.max(1, Math.abs(cur.y - start.y));
+      if (ev.shift) {
+        if (kind === 'line') {
+          const dx = cur.x - start.x,
+            dy = cur.y - start.y;
+          const a = Math.atan2(dy, dx);
+          const ang = Math.round(a / (Math.PI / 4)) * (Math.PI / 4);
+          const len = Math.hypot(dx, dy);
+          cur.x = start.x + Math.cos(ang) * len;
+          cur.y = start.y + Math.sin(ang) * len;
+        } else {
+          const m = Math.max(w, h);
+          w = h = m;
+        }
       }
+      this.previewRect =
+        kind === 'line'
+          ? {
+              x: Math.min(start.x, cur.x),
+              y: Math.min(start.y, cur.y),
+              w: Math.abs(cur.x - start.x),
+              h: Math.abs(cur.y - start.y),
+            }
+          : {
+              x: Math.floor(x1),
+              y: Math.floor(y1),
+              w: Math.floor(w),
+              h: Math.floor(h),
+            };
+      lastPreview = { start, cur, shift: ev.shift, state: { ...s } };
+    },
+    onPointerUp(ctx, ev, eng) {
+      if (!drawing) return;
+      drawing = false;
+      if (!lastPreview) {
+        this.previewRect = null;
+        return;
+      }
+      const { start: s, cur, state } = lastPreview;
+      const strokeColor = state.primaryColor,
+        fillColor = state.secondaryColor;
+      const lineWidth = state.brushSize,
+        fillOn = state.fillOn;
+      ctx.save();
+      ctx.imageSmoothingEnabled = store.getState().antialias;
+      ctx.lineWidth = lineWidth;
+      ctx.strokeStyle = strokeColor;
+      ctx.fillStyle = fillColor;
+      if (kind === 'line') {
+        ctx.beginPath();
+        ctx.moveTo(s.x + 0.5, s.y + 0.5);
+        ctx.lineTo(cur.x + 0.5, cur.y + 0.5);
+        ctx.stroke();
+        eng.expandPendingRectByRect(
+          Math.min(s.x, cur.x) - lineWidth,
+          Math.min(s.y, cur.y) - lineWidth,
+          Math.abs(cur.x - s.x) + lineWidth * 2,
+          Math.abs(cur.y - s.y) + lineWidth * 2,
+        );
+      } else if (kind === 'rect') {
+        const x = Math.min(s.x, cur.x),
+          y = Math.min(s.y, cur.y),
+          w = Math.abs(cur.x - s.x),
+          h = Math.abs(cur.y - s.y);
+        if (fillOn) ctx.fillRect(x, y, w, h);
+        ctx.strokeRect(x + 0.5, y + 0.5, w, h);
+        eng.expandPendingRectByRect(
+          x - lineWidth,
+          y - lineWidth,
+          w + lineWidth * 2,
+          h + lineWidth * 2,
+        );
+      } else if (kind === 'ellipse') {
+        const cx = (s.x + cur.x) / 2,
+          cy = (s.y + cur.y) / 2,
+          rx = Math.abs(cur.x - s.x) / 2,
+          ry = Math.abs(cur.y - s.y) / 2;
+        ctx.beginPath();
+        drawEllipsePath(ctx, cx, cy, rx, ry);
+        if (fillOn) ctx.fill();
+        ctx.stroke();
+        eng.expandPendingRectByRect(
+          cx - rx - lineWidth,
+          cy - ry - lineWidth,
+          rx * 2 + lineWidth * 2,
+          ry * 2 + lineWidth * 2,
+        );
+      }
+      ctx.restore();
+      this.previewRect = null;
+    },
+  };
+}

--- a/src/tools/textTool.js
+++ b/src/tools/textTool.js
@@ -1,12 +1,14 @@
-      function makeTextTool(store) {
-        return {
-          id: "text",
-          cursor: "text",
-          onPointerDown(ctx, ev, eng) {
-            cancelTextEditing(true);
-            createTextEditor(ev.img.x, ev.img.y, store);
-          },
-          onPointerMove() {},
-          onPointerUp() {},
-        };
-      }
+import { cancelTextEditing, createTextEditor } from '../main.js';
+
+export function makeTextTool(store) {
+  return {
+    id: 'text',
+    cursor: 'text',
+    onPointerDown(ctx, ev) {
+      cancelTextEditing(true);
+      createTextEditor(ev.img.x, ev.img.y, store);
+    },
+    onPointerMove() {},
+    onPointerUp() {},
+  };
+}


### PR DESCRIPTION
## Summary
- export paint utilities and engine from main module instead of assigning to `window`
- convert several tool scripts to ES modules and import them in the app
- clean up index.html and engine to consume modules through imports

## Testing
- `npm test` *(fails: could not read package.json)*
- `node --check src/main.js src/app.js src/tools/eyedropper.js src/tools/bucket.js src/tools/shape.js src/tools/textTool.js src/tools/catmull.js src/tools/bspline.js src/tools/nurbs.js`

------
https://chatgpt.com/codex/tasks/task_e_68c11218c40083248e6ca2ba98faa243