### PR TITLE
refactor: accept canvas in floodFill

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,6 @@
 import { PaintApp } from './app.js';
 import { toHex } from './utils/helpers.js';
-import { drawEllipsePath, floodFill } from './utils/drawing.js';
+import { drawEllipsePath, floodFill as floodFillImpl } from './utils/drawing.js';
 import {
   cancelTextEditing as cancelTextEdit,
   createTextEditor as createTextEditorImpl,
@@ -10,7 +10,10 @@ import { layers, activeLayer, bmp } from './layer.js';
 
 const app = new PaintApp();
 
-export { toHex, drawEllipsePath, floodFill, layers, activeLayer, bmp, isTextEditing };
+export const floodFill = (ctx, x0, y0, rgba, th = 0) =>
+  floodFillImpl(ctx, bmp, x0, y0, rgba, th);
+
+export { toHex, drawEllipsePath, layers, activeLayer, bmp, isTextEditing, floodFill };
 export const engine = app.engine;
 export const selectTool = (id) => app.selectTool(id);
 export const cancelTextEditing = (commit = false) =>

--- a/src/tools/bucket.js
+++ b/src/tools/bucket.js
@@ -1,4 +1,5 @@
 import { floodFill } from '../utils/drawing.js';
+import { bmp } from '../layer.js';
 
 export function makeBucket(store) {
   return {
@@ -11,6 +12,7 @@ export function makeBucket(store) {
         b = parseInt(h.slice(5, 7), 16);
       const p = floodFill(
         ctx,
+        bmp,
         Math.floor(ev.img.x),
         Math.floor(ev.img.y),
         [r, g, b, 255],

--- a/src/utils/drawing.js
+++ b/src/utils/drawing.js
@@ -1,4 +1,3 @@
-import { bmp } from "../layer.js";
 export function drawEllipsePath(ctx, cx, cy, rx, ry) {
   const k = 0.5522847498307936;
   const ox = rx * k;
@@ -10,7 +9,7 @@ export function drawEllipsePath(ctx, cx, cy, rx, ry) {
   ctx.bezierCurveTo(cx + ox, cy + ry, cx + rx, cy + oy, cx + rx, cy);
 }
 
-export function floodFill(ctx, x0, y0, rgba, th = 0) {
+export function floodFill(ctx, bmp, x0, y0, rgba, th = 0) {
   if (x0 < 0 || y0 < 0 || x0 >= bmp.width || y0 >= bmp.height) return null;
   const img = ctx.getImageData(0, 0, bmp.width, bmp.height);
   const d = img.data;


### PR DESCRIPTION
## Summary
- refactor floodFill to take a target canvas instead of using a global import
- update bucket tool and main export to pass canvas explicitly

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1147145bc8324b5563b1a6ecb0598