### PR TITLE
feat: add tool property panel and per-tool parameters

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,18 +39,10 @@
         <button class="tool" data-tool="pencil" title="P">鉛筆</button>
         <button class="tool" data-tool="pencil-click" title="Shift+P">鉛筆(オフドラッグ)</button>
         <button class="tool" data-tool="brush" title="B">ブラシ</button>
-        線幅 <input id="brush" type="range" min="1" max="64" value="4" />
-        滑らかさ <input id="smooth" type="range" min="0" max="1" step="0.05" value="0.55" />
-        間隔 <input id="spacing" type="range" min="0.1" max="1" step="0.05" value="0.4" />
         <button class="tool" data-tool="eraser" title="E">消しゴム</button>
         <button class="tool" data-tool="eraser-click" title="Shift+E">消しゴム(オフドラッグ)</button>
-        <button class="tool" data-tool="eyedropper" title="I">
-          スポイト
-        </button>
+        <button class="tool" data-tool="eyedropper" title="I">スポイト</button>
         <button class="tool" data-tool="bucket" title="F">バケツ</button>
-        <div class="sep"></div>
-        線色 <input id="color" type="color" value="#000000" /> 塗色
-        <input id="color2" type="color" value="#ffffff" />
       </div>
       <div id="geotools" class="row">
         <button class="tool" data-tool="line" title="L">直線</button>
@@ -65,25 +57,14 @@
           Bスプライン
         </button>
         <button class="tool" data-tool="nurbs" title="N">NURBS</button>
-        <label class="row badge">重み
-          <input id="nurbsWeight" type="number" value="1" step="0.1" style="width: 60px" /></label>
         <button class="tool" data-tool="ellipse-2" title="E">
           楕円(回転)
         </button>
         <button class="tool" data-tool="freehand" title="H">補間描画</button>
         <button class="tool" data-tool="freehand-click" title="Shift+H">補間描画(オフドラッグ)</button>
-        <label class="row badge">塗り <input id="fillOn" type="checkbox" checked /></label>
-        <label class="row badge">AA <input id="antialias" type="checkbox" /></label>
       </div>
       <div id="texttools" class="row">
         <button class="tool" data-tool="text" title="T">テキスト</button>
-        <select id="fontFamily">
-          <option value="system-ui, sans-serif">System</option>
-          <option value='"Noto Sans JP", sans-serif'>Noto Sans JP</option>
-          <option value="serif">Serif</option>
-          <option value="monospace">Monospace</option>
-        </select>
-        <input id="fontSize" type="number" min="8" max="200" value="24" style="width: 64px" />
       </div>
     </header>
 
@@ -147,6 +128,7 @@
   </div>
   <script type="module" src="src/gui/panels.js"></script>
   <script type="module" src="src/gui/toolbar.js"></script>
+  <script type="module" src="src/gui/tool-props.js"></script>
   <script src="src/tools/select-rect.js"></script>
   <script src="src/tools/pencil.js"></script>
   <script src="src/tools/pencil-click.js"></script>

--- a/src/app.js
+++ b/src/app.js
@@ -1,4 +1,5 @@
-import { initToolbar, setToolCallbacks, bindParameterControls } from './gui/toolbar.js';
+import { initToolbar, setToolCallbacks } from './gui/toolbar.js';
+import { initToolPropsPanel } from './gui/tool-props.js';
 import { initAdjustPanel, initLayerPanel, setAdjustCallbacks, setLayerCallbacks } from './gui/panels.js';
 import { Engine } from './engine.js';
 import { layers, activeLayer, bmp, renderLayers, addLayer, deleteLayer } from './layer.js';
@@ -64,7 +65,6 @@ export class PaintApp {
 
   initUI() {
     this.setupToolbarCallbacks();
-    this.setupParameterControls();
     this.setupLayerCallbacks();
     this.setupAdjustmentCallbacks();
   }
@@ -98,30 +98,8 @@ export class PaintApp {
     });
   }
 
-  setupParameterControls() {
-    bindParameterControls({
-      onBrushSizeChange: v => this.store.set({ brushSize: v }),
-      onSmoothChange: v => this.store.set({ smoothAlpha: v }),
-      onSpacingChange: v => this.store.set({ spacingRatio: v }),
-      onColorChange: v => this.store.set({ primaryColor: v }),
-      onColor2Change: v => this.store.set({ secondaryColor: v }),
-      onFillChange: v => this.store.set({ fillOn: v }),
-      onAntialiasChange: v => { this.store.set({ antialias: v }); this.engine.requestRepaint(); },
-      onFontFamilyChange: v => {
-        const ed = getActiveEditor();
-        if (ed) ed.style.fontFamily = v;
-      },
-      onFontSizeChange: v => {
-        const ed = getActiveEditor();
-        if (ed) {
-          let fs = parseFloat(v || '24');
-          if (isNaN(fs)) fs = 24;
-          ed.style.fontSize = fs + 'px';
-          ed.style.lineHeight = Math.round(fs * 1.4) + 'px';
-        }
-      }
-    });
-  }
+  // パラメータコントロールは左パネルで管理するため不要
+  setupParameterControls() {}
 
   setupLayerCallbacks() {
     setLayerCallbacks({
@@ -196,6 +174,7 @@ export class PaintApp {
     initToolbar();
     initAdjustPanel();
     initLayerPanel();
+    initToolPropsPanel(this.store, this.engine);
     initDocument(1280, 720, '#ffffff');
     this.engine.requestRepaint();
     checkSession();

--- a/src/core/store.js
+++ b/src/core/store.js
@@ -26,6 +26,27 @@ export class Store {
     this.subs.add(f);
     return () => this.subs.delete(f);
   }
+
+  getToolState(id) {
+    const tools = this.state.tools || (this.state.tools = {});
+    if (!tools[id]) {
+      tools[id] = { ...toolDefaults };
+    }
+    return { ...tools[id] };
+  }
+
+  setToolState(id, updates) {
+    const tools = this.state.tools || (this.state.tools = {});
+    const oldTool = { ...(tools[id] || { ...toolDefaults }) };
+    const oldState = { ...this.state };
+    tools[id] = { ...oldTool, ...updates };
+    this.subs.forEach((f) => f(this.state, oldState));
+    this.eventBus.emit('store:updated', {
+      oldState,
+      newState: this.state,
+      changes: { [id]: updates },
+    });
+  }
 }
 
 export function createStore(initial, eventBus) {
@@ -33,12 +54,19 @@ export function createStore(initial, eventBus) {
 }
 
 export const defaultState = {
-  toolId: "pencil",
-  primaryColor: "#000000",
-  secondaryColor: "#ffffff",
+  toolId: 'pencil',
+  tools: {},
+};
+
+export const toolDefaults = {
   brushSize: 4,
   smoothAlpha: 0.55,
   spacingRatio: 0.4,
+  primaryColor: '#000000',
+  secondaryColor: '#ffffff',
   fillOn: true,
   antialias: false,
+  nurbsWeight: 1,
+  fontFamily: 'system-ui, sans-serif',
+  fontSize: 24,
 };

--- a/src/engine.js
+++ b/src/engine.js
@@ -75,7 +75,9 @@ export class Engine {
     return p.x >= r.x && p.y >= r.y && p.x < r.x + r.w && p.y < r.y + r.h;
   }
   updateCursorInfo(pos) {
-    updateStatus(`x:${Math.floor(pos.img.x)}, y:${Math.floor(pos.img.y)}  線:${this.store.getState().primaryColor} 塗:${document.getElementById("color2").value}  幅:${this.store.getState().brushSize}`);
+    const tid = this.store.getState().toolId;
+    const ts = this.store.getToolState(tid);
+    updateStatus(`x:${Math.floor(pos.img.x)}, y:${Math.floor(pos.img.y)}  線:${ts.primaryColor} 塗:${ts.secondaryColor}  幅:${ts.brushSize}`);
   }
 
   beginStrokeSnapshot() {

--- a/src/gui/tool-props.js
+++ b/src/gui/tool-props.js
@@ -1,0 +1,133 @@
+import { getActiveEditor } from '../managers/text-editor.js';
+
+const strokeProps = [
+  { name: 'brushSize', label: '線幅', type: 'range', min: 1, max: 64, step: 1, default: 4 },
+  { name: 'primaryColor', label: '線色', type: 'color', default: '#000000' },
+];
+
+const smoothProps = [
+  { name: 'smoothAlpha', label: '滑らかさ', type: 'range', min: 0, max: 1, step: 0.05, default: 0.55 },
+  { name: 'spacingRatio', label: '間隔', type: 'range', min: 0.1, max: 1, step: 0.05, default: 0.4 },
+];
+
+const fillProps = [
+  { name: 'secondaryColor', label: '塗色', type: 'color', default: '#ffffff' },
+  { name: 'fillOn', label: '塗り', type: 'checkbox', default: true },
+];
+
+const aaProp = [{ name: 'antialias', label: 'AA', type: 'checkbox', default: false }];
+
+const textProps = [
+  {
+    name: 'fontFamily',
+    label: 'フォント',
+    type: 'select',
+    options: [
+      { value: 'system-ui, sans-serif', label: 'System' },
+      { value: '"Noto Sans JP", sans-serif', label: 'Noto Sans JP' },
+      { value: 'serif', label: 'Serif' },
+      { value: 'monospace', label: 'Monospace' },
+    ],
+    default: 'system-ui, sans-serif',
+  },
+  { name: 'fontSize', label: 'サイズ', type: 'number', min: 8, max: 200, step: 1, default: 24 },
+];
+
+const nurbsProp = [{ name: 'nurbsWeight', label: '重み', type: 'number', step: 0.1, default: 1 }];
+
+export const toolPropDefs = {
+  pencil: [...strokeProps],
+  'pencil-click': [...strokeProps],
+  brush: [...strokeProps, ...smoothProps],
+  eraser: [{ name: 'brushSize', label: 'サイズ', type: 'range', min: 1, max: 64, step: 1, default: 4 }],
+  'eraser-click': [{ name: 'brushSize', label: 'サイズ', type: 'range', min: 1, max: 64, step: 1, default: 4 }],
+  bucket: [{ name: 'primaryColor', label: '色', type: 'color', default: '#000000' }],
+  line: [...strokeProps, ...aaProp],
+  rect: [...strokeProps, ...fillProps, ...aaProp],
+  ellipse: [...strokeProps, ...fillProps, ...aaProp],
+  'ellipse-2': [...strokeProps, ...fillProps, ...aaProp],
+  quad: [...strokeProps],
+  cubic: [...strokeProps],
+  arc: [...strokeProps],
+  sector: [...strokeProps, ...fillProps],
+  catmull: [...strokeProps],
+  bspline: [...strokeProps],
+  nurbs: [...strokeProps, ...nurbsProp],
+  freehand: [...strokeProps, ...smoothProps],
+  'freehand-click': [...strokeProps, ...smoothProps],
+  text: [...strokeProps, ...textProps],
+  'select-rect': [],
+  eyedropper: [],
+};
+
+export function initToolPropsPanel(store, engine) {
+  const panel = document.getElementById('leftPanel');
+  if (!panel) return;
+
+  const render = (id) => {
+    const defs = toolPropDefs[id] || [];
+    panel.innerHTML = '';
+    defs.forEach((d) => {
+      const wrap = document.createElement('div');
+      wrap.className = 'prop-item';
+      const label = document.createElement('label');
+      label.textContent = d.label;
+      label.style.display = 'block';
+      let input;
+      if (d.type === 'select') {
+        input = document.createElement('select');
+        d.options.forEach((o) => {
+          const opt = document.createElement('option');
+          opt.value = o.value;
+          opt.textContent = o.label;
+          input.appendChild(opt);
+        });
+      } else {
+        input = document.createElement('input');
+        input.type = d.type;
+        if (d.min !== undefined) input.min = d.min;
+        if (d.max !== undefined) input.max = d.max;
+        if (d.step !== undefined) input.step = d.step;
+      }
+      const state = store.getToolState(id);
+      const val = state[d.name] ?? d.default;
+      if (d.type === 'checkbox') input.checked = !!val; else input.value = val;
+      const evt = d.type === 'checkbox' ? 'change' : 'input';
+      input.addEventListener(evt, () => {
+        const v = d.type === 'checkbox' ? input.checked : (d.type === 'number' ? parseFloat(input.value) : input.value);
+        store.setToolState(id, { [d.name]: v });
+        if (d.name === 'antialias') engine?.requestRepaint?.();
+        if (id === 'text') {
+          const ed = getActiveEditor();
+          if (ed) {
+            if (d.name === 'fontFamily') ed.style.fontFamily = v;
+            if (d.name === 'fontSize') {
+              ed.style.fontSize = v + 'px';
+              ed.style.lineHeight = Math.round(v * 1.4) + 'px';
+            }
+            if (d.name === 'primaryColor') ed.style.color = v;
+          }
+        }
+      });
+      wrap.appendChild(label);
+      wrap.appendChild(input);
+      panel.appendChild(wrap);
+    });
+    panel.style.display = defs.length ? 'block' : 'none';
+  };
+
+  render(store.getState().toolId);
+  store.subscribe((s, old) => {
+    if (s.toolId !== old.toolId) {
+      render(s.toolId);
+    } else {
+      const tid = s.toolId;
+      const ns = s.tools?.[tid];
+      const os = old.tools?.[tid];
+      if (JSON.stringify(ns) !== JSON.stringify(os)) render(tid);
+    }
+  });
+}
+
+// expose definitions for other scripts if needed
+window.initToolPropsPanel = initToolPropsPanel;

--- a/src/managers/text-editor.js
+++ b/src/managers/text-editor.js
@@ -17,13 +17,14 @@ export function createTextEditor(x, y, store, engine, editorLayer, layers, activ
   editor.style.top = Math.floor(y) + "px";
   editor.style.minWidth = "80px";
 
-  const ff = document.getElementById("fontFamily").value;
-  let fs = parseFloat(document.getElementById("fontSize").value || "24");
+  const ts = store.getToolState('text');
+  const ff = ts.fontFamily;
+  let fs = parseFloat(ts.fontSize || 24);
   if (isNaN(fs)) fs = 24;
   editor.style.fontFamily = ff;
-  editor.style.fontSize = fs + "px";
-  editor.style.lineHeight = Math.round(fs * 1.4) + "px";
-  editor.style.color = store.getState().primaryColor;
+  editor.style.fontSize = fs + 'px';
+  editor.style.lineHeight = Math.round(fs * 1.4) + 'px';
+  editor.style.color = ts.primaryColor;
 
   editor.innerHTML = "<br>";
   editorLayer.appendChild(editor);

--- a/src/tools/arc.js
+++ b/src/tools/arc.js
@@ -1,4 +1,5 @@
       function makeArc(store) {
+        const id = 'arc';
         let stage = 0,
           cx = 0,
           cy = 0,
@@ -6,8 +7,8 @@
           start = 0,
           end = 0;
         return {
-          id: "arc",
-          cursor: "crosshair",
+          id,
+          cursor: 'crosshair',
           previewRect: null,
           onPointerDown(ctx, ev, eng) {
             if (stage === 0) {
@@ -20,7 +21,7 @@
               end = start;
               stage = 2;
             } else if (stage === 2) {
-              const s = store.getState();
+              const s = store.getToolState(id);
               ctx.save();
               ctx.lineWidth = s.brushSize;
               ctx.strokeStyle = s.primaryColor;
@@ -47,7 +48,7 @@
           onPointerUp() {},
           drawPreview(octx) {
             if (stage === 2) {
-              const s = store.getState();
+              const s = store.getToolState(id);
               octx.save();
               octx.lineWidth = s.brushSize;
               octx.strokeStyle = s.primaryColor;

--- a/src/tools/brush.js
+++ b/src/tools/brush.js
@@ -1,9 +1,10 @@
       function makeBrush(store) {
+        const id = 'brush';
         let pts = [],
           drawing = false;
         return {
-          id: "brush",
-          cursor: "crosshair",
+          id,
+          cursor: 'crosshair',
           previewRect: null,
           onPointerDown(ctx, ev, eng) {
             eng.clearSelection();
@@ -13,7 +14,7 @@
           onPointerMove(ctx, ev, eng) {
             if (!drawing) return;
             pts.push({ ...ev.img });
-            const s = store.getState();
+            const s = store.getToolState(id);
             if (pts.length < 4) {
               const p1 = pts[pts.length - 2];
               const p2 = pts[pts.length - 1];
@@ -76,7 +77,7 @@
               const cr = [];
               for (let j = 0; j <= 8; j++)
                 cr.push(catmullRom(p0, p1, p2, p3, j / 8));
-              const s = store.getState();
+              const s = store.getToolState(id);
               ctx.save();
               ctx.lineCap = "round";
               ctx.lineJoin = "round";

--- a/src/tools/bspline.js
+++ b/src/tools/bspline.js
@@ -2,6 +2,7 @@ import { bspline } from '../spline.js';
 import { engine } from '../main.js';
 
 export function makeBSpline(store) {
+  const id = 'bspline';
   let pts = [],
     fresh = true,
     hover = null;
@@ -17,7 +18,7 @@ export function makeBSpline(store) {
       eng.requestRepaint();
       return;
     }
-    const s = store.getState();
+    const s = store.getToolState(id);
     const cr = bspline(pts);
     ctx.save();
     ctx.lineWidth = s.brushSize;
@@ -80,7 +81,7 @@ export function makeBSpline(store) {
     },
     onPointerUp() {},
     drawPreview(octx) {
-      const s = store.getState();
+      const s = store.getToolState(id);
       octx.save();
       octx.lineWidth = s.brushSize;
       octx.strokeStyle = s.primaryColor;

--- a/src/tools/bucket.js
+++ b/src/tools/bucket.js
@@ -6,7 +6,7 @@ export function makeBucket(store) {
     id: 'bucket',
     cursor: 'pointer',
     onPointerDown(ctx, ev, eng) {
-      const h = store.getState().primaryColor;
+      const h = store.getToolState('bucket').primaryColor;
       const r = parseInt(h.slice(1, 3), 16),
         g = parseInt(h.slice(3, 5), 16),
         b = parseInt(h.slice(5, 7), 16);

--- a/src/tools/catmull.js
+++ b/src/tools/catmull.js
@@ -3,6 +3,7 @@ import { bctx } from '../layer.js';
 import { engine } from '../main.js';
 
 export function makeCatmull(store) {
+  const id = 'catmull';
   let pts = [],
     fresh = true;
   const reset = () => {
@@ -15,7 +16,7 @@ export function makeCatmull(store) {
       eng.requestRepaint();
       return;
     }
-    const s = store.getState();
+    const s = store.getToolState(id);
     const cr = catmullRomSpline(pts);
     ctx.save();
     ctx.lineWidth = s.brushSize;
@@ -78,8 +79,8 @@ export function makeCatmull(store) {
       if (pts.length > 1) {
         const cr = catmullRomSpline(pts);
         octx.save();
-        octx.lineWidth = store.getState().brushSize;
-        octx.strokeStyle = store.getState().primaryColor;
+        octx.lineWidth = store.getToolState(id).brushSize;
+        octx.strokeStyle = store.getToolState(id).primaryColor;
         octx.beginPath();
         octx.moveTo(cr[0].x + 0.5, cr[0].y + 0.5);
         for (let i = 1; i < cr.length; i++)

--- a/src/tools/cubic.js
+++ b/src/tools/cubic.js
@@ -1,12 +1,13 @@
       function makeCubic(store) {
+        const id = 'cubic';
         let stage = 0,
           p0 = null,
           p1 = null,
           p2 = null,
           p3 = null;
         return {
-          id: "cubic",
-          cursor: "crosshair",
+          id,
+          cursor: 'crosshair',
           previewRect: null,
           onPointerDown(ctx, ev, eng) {
             if (stage === 0) {
@@ -20,7 +21,7 @@
               stage = 3;
             } else if (stage === 3) {
               p3 = { ...ev.img };
-              const s = store.getState();
+              const s = store.getToolState(id);
               ctx.save();
               ctx.lineWidth = s.brushSize;
               ctx.strokeStyle = s.primaryColor;
@@ -61,7 +62,7 @@
           },
           onPointerUp() {},
           drawPreview(octx) {
-            const s = store.getState();
+            const s = store.getToolState(id);
             octx.save();
             octx.lineWidth = s.brushSize;
             octx.strokeStyle = s.primaryColor;

--- a/src/tools/ellipse-2.js
+++ b/src/tools/ellipse-2.js
@@ -1,4 +1,5 @@
       function makeEllipse2(store) {
+        const id = 'ellipse-2';
         let stage = 0,
           cx = 0,
           cy = 0,
@@ -6,8 +7,8 @@
           ry = 0,
           rot = 0;
         return {
-          id: "ellipse-2",
-          cursor: "crosshair",
+          id,
+          cursor: 'crosshair',
           previewRect: null,
           onPointerDown(ctx, ev, eng) {
             if (stage === 0) {
@@ -20,14 +21,14 @@
               rot = 0;
               stage = 2;
             } else if (stage === 2) {
-              const s = store.getState();
+              const s = store.getToolState(id);
               ctx.save();
               ctx.lineWidth = s.brushSize;
               ctx.strokeStyle = s.primaryColor;
-              if (store.getState().fillOn) ctx.fillStyle = s.secondaryColor;
+              if (store.getToolState(id).fillOn) ctx.fillStyle = s.secondaryColor;
               ctx.beginPath();
               ctx.ellipse(cx, cy, rx, ry, rot, 0, Math.PI * 2);
-              if (store.getState().fillOn) ctx.fill();
+              if (store.getToolState(id).fillOn) ctx.fill();
               ctx.stroke();
               ctx.restore();
               eng.expandPendingRectByRect(
@@ -50,7 +51,7 @@
           onPointerUp() {},
           drawPreview(octx) {
             if (stage > 0) {
-              const s = store.getState();
+              const s = store.getToolState(id);
               octx.save();
               octx.lineWidth = s.brushSize;
               octx.strokeStyle = s.primaryColor;

--- a/src/tools/eraser-click.js
+++ b/src/tools/eraser-click.js
@@ -1,9 +1,10 @@
       function makeEraserClick(store) {
+        const id = 'eraser-click';
         let drawing = false,
           last = null;
         return {
-          id: "eraser-click",
-          cursor: "cell",
+          id,
+          cursor: 'cell',
           onPointerDown(ctx, ev, eng) {
             eng.clearSelection();
             if (!drawing) {
@@ -12,16 +13,16 @@
               eng.expandPendingRect(
                 ev.img.x,
                 ev.img.y,
-                store.getState().brushSize
+                store.getToolState(id).brushSize
               );
-              erase(ctx, ev.img, store);
+              erase(ctx, ev.img);
             } else {
               eng.expandPendingRect(
                 ev.img.x,
                 ev.img.y,
-                store.getState().brushSize
+                store.getToolState(id).brushSize
               );
-              erase(ctx, ev.img, store);
+              erase(ctx, ev.img);
               drawing = false;
               last = null;
             }
@@ -31,14 +32,14 @@
             eng.expandPendingRect(
               ev.img.x,
               ev.img.y,
-              store.getState().brushSize
+              store.getToolState(id).brushSize
             );
-            erase(ctx, ev.img, store);
+            erase(ctx, ev.img);
           },
           onPointerUp() {},
         };
-        function erase(ctx, img, store) {
-          const s = store.getState();
+        function erase(ctx, img) {
+          const s = store.getToolState(id);
           ctx.save();
           ctx.globalCompositeOperation = "destination-out";
           ctx.lineCap = "round";

--- a/src/tools/eraser.js
+++ b/src/tools/eraser.js
@@ -1,9 +1,10 @@
       function makeEraser(store) {
+        const id = 'eraser';
         let drawing = false,
           last = null;
         return {
-          id: "eraser",
-          cursor: "cell",
+          id,
+          cursor: 'cell',
           onPointerDown(ctx, ev, eng) {
             eng.clearSelection();
             drawing = true;
@@ -11,26 +12,26 @@
             eng.expandPendingRect(
               ev.img.x,
               ev.img.y,
-              store.getState().brushSize
+              store.getToolState(id).brushSize
             );
-            erase(ctx, ev.img, store);
+            erase(ctx, ev.img);
           },
           onPointerMove(ctx, ev, eng) {
             if (!drawing) return;
             eng.expandPendingRect(
               ev.img.x,
               ev.img.y,
-              store.getState().brushSize
+              store.getToolState(id).brushSize
             );
-            erase(ctx, ev.img, store);
+            erase(ctx, ev.img);
           },
           onPointerUp() {
             drawing = false;
             last = null;
           },
         };
-        function erase(ctx, img, store) {
-          const s = store.getState();
+        function erase(ctx, img) {
+          const s = store.getToolState(id);
           ctx.save();
           ctx.globalCompositeOperation = "destination-out";
           ctx.lineCap = "round";

--- a/src/tools/eyedropper.js
+++ b/src/tools/eyedropper.js
@@ -10,7 +10,7 @@ export function makeEyedropper(store) {
         y = Math.floor(ev.img.y);
       if (x < 0 || y < 0 || x >= bmp.width || y >= bmp.height) return;
       const { data } = bctx.getImageData(x, y, 1, 1);
-      store.set({ primaryColor: toHex(data[0], data[1], data[2]) });
+      store.setToolState('eyedropper', { primaryColor: toHex(data[0], data[1], data[2]) });
     },
     onPointerMove() {},
     onPointerUp() {},

--- a/src/tools/freehand-click.js
+++ b/src/tools/freehand-click.js
@@ -1,9 +1,10 @@
       function makeFreehandClick(store) {
+        const id = 'freehand-click';
         let pts = [],
           drawing = false;
         return {
-          id: "freehand-click",
-          cursor: "crosshair",
+          id,
+          cursor: 'crosshair',
           previewRect: null,
           onPointerDown(ctx, ev, eng) {
             if (!drawing) {
@@ -11,7 +12,7 @@
               pts = [{ ...ev.img }];
             } else {
               pts.push({ ...ev.img });
-              const s = store.getState();
+              const s = store.getToolState(id);
               const sm = catmullRomSpline(pts, 8);
               ctx.save();
               ctx.lineWidth = s.brushSize;
@@ -52,8 +53,8 @@
             if (drawing && pts.length > 1) {
               const sm = catmullRomSpline(pts, 8);
               octx.save();
-              octx.lineWidth = store.getState().brushSize;
-              octx.strokeStyle = store.getState().primaryColor;
+              octx.lineWidth = store.getToolState(id).brushSize;
+              octx.strokeStyle = store.getToolState(id).primaryColor;
               octx.beginPath();
               octx.moveTo(sm[0].x + 0.5, sm[0].y + 0.5);
               for (let i = 1; i < sm.length; i++)

--- a/src/tools/freehand.js
+++ b/src/tools/freehand.js
@@ -1,9 +1,10 @@
       function makeFreehand(store) {
+        const id = 'freehand';
         let pts = [],
           drawing = false;
         return {
-          id: "freehand",
-          cursor: "crosshair",
+          id,
+          cursor: 'crosshair',
           previewRect: null,
           onPointerDown(ctx, ev) {
             drawing = true;
@@ -16,7 +17,7 @@
             if (!drawing) return;
             drawing = false;
             pts.push({ ...ev.img });
-            const s = store.getState();
+            const s = store.getToolState(id);
             const sm = catmullRomSpline(pts, 8);
             ctx.save();
             ctx.lineWidth = s.brushSize;
@@ -51,8 +52,8 @@
             if (drawing && pts.length > 1) {
               const sm = catmullRomSpline(pts, 8);
               octx.save();
-              octx.lineWidth = store.getState().brushSize;
-              octx.strokeStyle = store.getState().primaryColor;
+              octx.lineWidth = store.getToolState(id).brushSize;
+              octx.strokeStyle = store.getToolState(id).primaryColor;
               octx.beginPath();
               octx.moveTo(sm[0].x + 0.5, sm[0].y + 0.5);
               for (let i = 1; i < sm.length; i++)

--- a/src/tools/nurbs.js
+++ b/src/tools/nurbs.js
@@ -1,22 +1,21 @@
 import { nurbs } from '../spline.js';
 import { engine } from '../main.js';
 
-const nurbsWeightEl = document.getElementById('nurbsWeight');
-
 export function makeNURBS(store) {
+  const id = 'nurbs';
   let pts = [],
     ws = [],
     hover = null;
 
   function finalize(ctx, eng) {
     if (pts.length < 4) return;
-    const s = store.getState();
+    const s = store.getToolState(id);
     const cr = nurbs(pts, ws);
     if (!cr.length) {
       pts = [];
       ws = [];
       hover = null;
-      nurbsWeightEl.value = '1';
+      store.setToolState(id, { nurbsWeight: 1 });
       eng.requestRepaint();
       return;
     }
@@ -55,7 +54,7 @@ export function makeNURBS(store) {
     pts = [];
     ws = [];
     hover = null;
-    nurbsWeightEl.value = '1';
+    store.setToolState(id, { nurbsWeight: 1 });
   }
 
   window.addEventListener('keydown', (e) => {
@@ -70,14 +69,14 @@ export function makeNURBS(store) {
       if (ev.button === 0 && ev.detail === 2) {
         if (pts.length === 0) eng.beginStrokeSnapshot();
         pts.push({ ...ev.img });
-        const w = parseFloat(nurbsWeightEl.value);
+        const w = parseFloat(store.getToolState(id).nurbsWeight);
         ws.push(Number.isFinite(w) && w > 0 ? w : 1);
         finalize(ctx, eng);
         return;
       }
       if (pts.length === 0) eng.beginStrokeSnapshot();
       pts.push({ ...ev.img });
-      const w = parseFloat(nurbsWeightEl.value);
+      const w = parseFloat(store.getToolState(id).nurbsWeight);
       ws.push(Number.isFinite(w) && w > 0 ? w : 1);
     },
     onPointerMove(ctx, ev) {
@@ -85,7 +84,7 @@ export function makeNURBS(store) {
     },
     onPointerUp() {},
     drawPreview(octx) {
-      const s = store.getState();
+      const s = store.getToolState(id);
       octx.save();
       octx.lineWidth = s.brushSize;
       octx.strokeStyle = s.primaryColor;

--- a/src/tools/pencil-click.js
+++ b/src/tools/pencil-click.js
@@ -1,9 +1,10 @@
       function makePencilClick(store) {
+        const id = 'pencil-click';
         let drawing = false,
           last = null;
         return {
-          id: "pencil-click",
-          cursor: "crosshair",
+          id,
+          cursor: 'crosshair',
           onPointerDown(ctx, ev, eng) {
             eng.clearSelection();
             if (!drawing) {
@@ -12,16 +13,16 @@
               eng.expandPendingRect(
                 ev.img.x,
                 ev.img.y,
-                store.getState().brushSize
+                store.getToolState(id).brushSize
               );
-              stroke(ctx, ev.img, store);
+              stroke(ctx, ev.img);
             } else {
               eng.expandPendingRect(
                 ev.img.x,
                 ev.img.y,
-                store.getState().brushSize
+                store.getToolState(id).brushSize
               );
-              stroke(ctx, ev.img, store);
+              stroke(ctx, ev.img);
               drawing = false;
               last = null;
             }
@@ -31,14 +32,14 @@
             eng.expandPendingRect(
               ev.img.x,
               ev.img.y,
-              store.getState().brushSize
+              store.getToolState(id).brushSize
             );
-            stroke(ctx, ev.img, store);
+            stroke(ctx, ev.img);
           },
           onPointerUp() {},
         };
-        function stroke(ctx, img, store) {
-          const s = store.getState();
+        function stroke(ctx, img) {
+          const s = store.getToolState(id);
           ctx.save();
           ctx.lineCap = "round";
           ctx.lineJoin = "round";

--- a/src/tools/pencil.js
+++ b/src/tools/pencil.js
@@ -1,9 +1,10 @@
       function makePencil(store) {
+        const id = 'pencil';
         let drawing = false,
           last = null;
         return {
-          id: "pencil",
-          cursor: "crosshair",
+          id,
+          cursor: 'crosshair',
           onPointerDown(ctx, ev, eng) {
             eng.clearSelection();
             drawing = true;
@@ -11,29 +12,29 @@
             eng.expandPendingRect(
               ev.img.x,
               ev.img.y,
-              store.getState().brushSize
+              store.getToolState(id).brushSize
             );
-            stroke(ctx, ev.img, store);
+            stroke(ctx, ev.img);
           },
           onPointerMove(ctx, ev, eng) {
             if (!drawing) return;
             eng.expandPendingRect(
               ev.img.x,
               ev.img.y,
-              store.getState().brushSize
+              store.getToolState(id).brushSize
             );
-            stroke(ctx, ev.img, store);
+            stroke(ctx, ev.img);
           },
           onPointerUp() {
             drawing = false;
             last = null;
           },
         };
-        function stroke(ctx, img, store) {
-          const s = store.getState();
+        function stroke(ctx, img) {
+          const s = store.getToolState(id);
           ctx.save();
-          ctx.lineCap = "round";
-          ctx.lineJoin = "round";
+          ctx.lineCap = 'round';
+          ctx.lineJoin = 'round';
           ctx.strokeStyle = s.primaryColor;
           ctx.lineWidth = s.brushSize;
           ctx.beginPath();

--- a/src/tools/quadratic.js
+++ b/src/tools/quadratic.js
@@ -1,11 +1,12 @@
       function makeQuadratic(store) {
+        const id = 'quad';
         let stage = 0,
           p0 = null,
           p1 = null,
           p2 = null;
         return {
-          id: "quad",
-          cursor: "crosshair",
+          id,
+          cursor: 'crosshair',
           previewRect: null,
           onPointerDown(ctx, ev, eng) {
             if (stage === 0) {
@@ -16,7 +17,7 @@
               p1 = { x: (p0.x + p2.x) / 2, y: (p0.y + p2.y) / 2 };
               stage = 2;
             } else if (stage === 2) {
-              const s = store.getState();
+              const s = store.getToolState(id);
               ctx.save();
               ctx.lineWidth = s.brushSize;
               ctx.strokeStyle = s.primaryColor;
@@ -52,7 +53,7 @@
           onPointerUp() {},
           drawPreview(octx) {
             if (stage === 2) {
-              const s = store.getState();
+            const s = store.getToolState(id);
               octx.save();
               octx.lineWidth = s.brushSize;
               octx.strokeStyle = s.primaryColor;

--- a/src/tools/sector.js
+++ b/src/tools/sector.js
@@ -1,4 +1,5 @@
       function makeSector(store) {
+        const id = 'sector';
         let stage = 0,
           cx = 0,
           cy = 0,
@@ -6,8 +7,8 @@
           start = 0,
           end = 0;
         return {
-          id: "sector",
-          cursor: "crosshair",
+          id,
+          cursor: 'crosshair',
           previewRect: null,
           onPointerDown(ctx, ev, eng) {
             if (stage === 0) {
@@ -20,18 +21,18 @@
               end = start;
               stage = 2;
             } else if (stage === 2) {
-              const s = store.getState();
+              const s = store.getToolState(id);
               ctx.save();
               ctx.lineWidth = s.brushSize;
-              ctx.fillStyle = store.getState().fillOn
+              ctx.fillStyle = store.getToolState(id).fillOn
                 ? s.secondaryColor
-                : "transparent";
+                : 'transparent';
               ctx.strokeStyle = s.primaryColor;
               ctx.beginPath();
               ctx.moveTo(cx, cy);
               ctx.arc(cx, cy, r, start, end);
               ctx.closePath();
-              if (store.getState().fillOn) ctx.fill();
+              if (store.getToolState(id).fillOn) ctx.fill();
               ctx.stroke();
               ctx.restore();
               eng.expandPendingRectByRect(
@@ -51,7 +52,7 @@
           onPointerUp() {},
           drawPreview(octx) {
             if (stage === 2) {
-              const s = store.getState();
+              const s = store.getToolState(id);
               octx.save();
               octx.lineWidth = s.brushSize;
               octx.strokeStyle = s.primaryColor;

--- a/src/tools/shape.js
+++ b/src/tools/shape.js
@@ -17,7 +17,7 @@ export function makeShape(kind, store) {
     onPointerMove(ctx, ev, eng) {
       if (!drawing) return;
       const cur = { ...ev.img };
-      const s = store.getState();
+      const s = store.getToolState(kind);
       const x1 = Math.min(start.x, cur.x),
         y1 = Math.min(start.y, cur.y);
       let w = Math.max(1, Math.abs(cur.x - start.x)),
@@ -65,7 +65,7 @@ export function makeShape(kind, store) {
       const lineWidth = state.brushSize,
         fillOn = state.fillOn;
       ctx.save();
-      ctx.imageSmoothingEnabled = store.getState().antialias;
+      ctx.imageSmoothingEnabled = store.getToolState(kind).antialias;
       ctx.lineWidth = lineWidth;
       ctx.strokeStyle = strokeColor;
       ctx.fillStyle = fillColor;


### PR DESCRIPTION
## Summary
- render tool-specific properties in the left panel
- store parameters separately for each tool and stop sharing values
- update drawing tools to use their own settings

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1ea8d915883248566201fb66b844e