### PR TITLE
Add headers and scrollable bodies to panels

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,8 +69,10 @@
     </header>
 
     <div id="stage">
-      <div id="leftPanel" class="side-panel">
-        <!-- 左サイドパネル（将来の拡張用） -->
+      <div id="leftPanel" class="side-panel panel" data-name="ツール">
+        <div class="panel-header"></div>
+        <div class="panel-body"></div>
+        <div class="panel-footer"></div>
       </div>
 
       <div id="canvasArea">
@@ -79,14 +81,16 @@
         <div id="editorLayer"></div>
       </div>
 
-      <div id="rightPanel" class="side-panel">
-        <div id="layerPanel">
+      <div id="layerPanel" class="side-panel panel" data-name="レイヤー">
+        <div class="panel-header"></div>
+        <div class="panel-body">
           <div style="display: flex; gap: 4px; align-items: center">
             <button id="addLayerBtn">＋</button>
             <button id="delLayerBtn">－</button>
           </div>
           <ul id="layerList"></ul>
         </div>
+        <div class="panel-footer"></div>
       </div>
     </div>
 

--- a/src/app.js
+++ b/src/app.js
@@ -1,6 +1,6 @@
 import { initToolbar, setToolCallbacks } from './gui/toolbar.js';
 import { initToolPropsPanel } from './gui/tool-props.js';
-import { initAdjustPanel, initLayerPanel, setAdjustCallbacks, setLayerCallbacks } from './gui/panels.js';
+import { initAdjustPanel, initLayerPanel, setAdjustCallbacks, setLayerCallbacks, initPanelHeaders } from './gui/panels.js';
 import { Engine } from './engine.js';
 import { layers, activeLayer, bmp, renderLayers, addLayer, deleteLayer } from './layer.js';
 import { initIO, initDocument, openImageFile, triggerSave, doCopy, doCut, handleClipboardItems, restoreSession, checkSession, saveSessionDebounced } from './io.js';
@@ -174,6 +174,7 @@ export class PaintApp {
     initToolbar();
     initAdjustPanel();
     initLayerPanel();
+    initPanelHeaders();
     initToolPropsPanel(this.store, this.engine);
     initDocument(1280, 720, '#ffffff');
     this.engine.requestRepaint();

--- a/src/gui/panels.js
+++ b/src/gui/panels.js
@@ -3,6 +3,14 @@
 let adjustCallbacks = {};
 let layerCallbacks = {};
 
+export function initPanelHeaders() {
+  document.querySelectorAll('.panel').forEach(p => {
+    const header = p.querySelector('.panel-header');
+    const name = p.dataset.name || p.id;
+    if (header) header.textContent = `${name} (ID: ${p.id})`;
+  });
+}
+
 export function initAdjustPanel() {
   const adjPanel = document.getElementById('adjustPanel');
   const adjBtn = document.getElementById('adjustBtn');

--- a/src/gui/tool-props.js
+++ b/src/gui/tool-props.js
@@ -63,10 +63,12 @@ export const toolPropDefs = {
 export function initToolPropsPanel(store, engine) {
   const panel = document.getElementById('leftPanel');
   if (!panel) return;
+  const body = panel.querySelector('.panel-body');
+  if (!body) return;
 
   const render = (id) => {
     const defs = toolPropDefs[id] || [];
-    panel.innerHTML = '';
+    body.innerHTML = '';
     defs.forEach((d) => {
       const wrap = document.createElement('div');
       wrap.className = 'prop-item';
@@ -111,7 +113,7 @@ export function initToolPropsPanel(store, engine) {
       });
       wrap.appendChild(label);
       wrap.appendChild(input);
-      panel.appendChild(wrap);
+      body.appendChild(wrap);
     });
     panel.style.display = defs.length ? 'block' : 'none';
   };

--- a/styles.css
+++ b/styles.css
@@ -99,7 +99,25 @@ footer {
 .side-panel {
   background: #fafafa;
   border: 1px solid #ddd;
-  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+}
+
+.panel-header {
+  padding: 4px 8px;
+  background: #eee;
+  border-bottom: 1px solid #ddd;
+}
+
+.panel-footer {
+  padding: 4px 8px;
+  background: #eee;
+  border-top: 1px solid #ddd;
+}
+
+.panel-body {
+  flex: 1;
+  overflow: scroll;
   padding: 8px;
 }
 
@@ -107,7 +125,7 @@ footer {
   border-right: 1px solid #ddd;
 }
 
-#rightPanel {
+#layerPanel {
   border-left: 1px solid #ddd;
 }
 
@@ -269,12 +287,10 @@ input[type="number"] {
   user-select: text;
 }
 
-#layerPanel {
+#layerPanel .panel-body {
   display: flex;
   flex-direction: column;
   gap: 4px;
-  max-height: 200px;
-  overflow-y: auto;
 }
 
 #layerList {


### PR DESCRIPTION
## Summary
- Add header and footer sections to tool and layer panels
- Show panel name and ID in header via new initPanelHeaders helper
- Ensure panel bodies always display scrollbars and update tool property rendering accordingly

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1f1fe578c83248622329f103ee52d