### PR TITLE
Add Minimal freehand drawing tool

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,6 +39,7 @@
         <button class="tool" data-tool="pencil" title="P">鉛筆</button>
         <button class="tool" data-tool="pencil-click" title="Shift+P">鉛筆(オフドラッグ)</button>
         <button class="tool" data-tool="brush" title="B">ブラシ</button>
+        <button class="tool" data-tool="minimal">Minimal</button>
         <button class="tool" data-tool="eraser" title="E">消しゴム</button>
         <button class="tool" data-tool="eraser-click" title="Shift+E">消しゴム(オフドラッグ)</button>
         <button class="tool" data-tool="eyedropper" title="I">スポイト</button>
@@ -134,11 +135,12 @@
   <script type="module" src="src/gui/toolbar.js"></script>
   <script type="module" src="src/gui/tool-props.js"></script>
   <script src="src/tools/select-rect.js"></script>
-  <script src="src/tools/pencil.js"></script>
-  <script src="src/tools/pencil-click.js"></script>
-  <script src="src/tools/brush.js"></script>
-  <script src="src/tools/eraser.js"></script>
-  <script src="src/tools/eraser-click.js"></script>
+    <script src="src/tools/pencil.js"></script>
+    <script src="src/tools/pencil-click.js"></script>
+    <script src="src/tools/brush.js"></script>
+    <script src="src/tools/minimal.js"></script>
+    <script src="src/tools/eraser.js"></script>
+    <script src="src/tools/eraser-click.js"></script>
   <script src="src/tools/quadratic.js"></script>
   <script src="src/tools/cubic.js"></script>
   <script src="src/tools/arc.js"></script>

--- a/src/app.js
+++ b/src/app.js
@@ -43,6 +43,7 @@ export class PaintApp {
     this.engine.register(makePencil(this.store));
     this.engine.register(makePencilClick(this.store));
     this.engine.register(makeBrush(this.store));
+    this.engine.register(makeMinimal(this.store));
     this.engine.register(makeEraser(this.store));
     this.engine.register(makeEraserClick(this.store));
     this.engine.register(makeEyedropper(this.store));

--- a/src/gui/tool-props.js
+++ b/src/gui/tool-props.js
@@ -39,6 +39,10 @@ export const toolPropDefs = {
   pencil: [...strokeProps],
   'pencil-click': [...strokeProps],
   brush: [...strokeProps, ...smoothProps],
+  minimal: [
+    { name: 'brushSize', label: '線幅', type: 'range', min: 1, max: 6, step: 1, default: 4 },
+    { name: 'primaryColor', label: '線色', type: 'color', default: '#000000' },
+  ],
   eraser: [{ name: 'brushSize', label: 'サイズ', type: 'range', min: 1, max: 64, step: 1, default: 4 }],
   'eraser-click': [{ name: 'brushSize', label: 'サイズ', type: 'range', min: 1, max: 64, step: 1, default: 4 }],
   bucket: [{ name: 'primaryColor', label: '色', type: 'color', default: '#000000' }],

--- a/src/tools/minimal.js
+++ b/src/tools/minimal.js
@@ -1,0 +1,44 @@
+function makeMinimal(store) {
+  const id = 'minimal';
+  let drawing = false;
+  let prev = null;
+  return {
+    id,
+    cursor: 'crosshair',
+    onPointerDown(ctx, ev, eng) {
+      eng.clearSelection();
+      drawing = true;
+      prev = { ...ev.img };
+    },
+    onPointerMove(ctx, ev, eng) {
+      if (!drawing) return;
+      drawSegment(prev, ev.img, ctx, eng);
+      prev = { ...ev.img };
+    },
+    onPointerUp(ctx, ev, eng) {
+      if (!drawing) return;
+      drawSegment(prev, ev.img, ctx, eng);
+      drawing = false;
+      prev = null;
+    },
+    drawPreview() {},
+  };
+  function drawSegment(p1, p2, ctx, eng) {
+    const s = store.getToolState(id);
+    ctx.save();
+    ctx.lineCap = 'round';
+    ctx.lineJoin = 'round';
+    ctx.strokeStyle = s.primaryColor;
+    ctx.lineWidth = s.brushSize;
+    ctx.beginPath();
+    ctx.moveTo(p1.x + 0.5, p1.y + 0.5);
+    ctx.lineTo(p2.x + 0.5, p2.y + 0.5);
+    ctx.stroke();
+    ctx.restore();
+    const minX = Math.min(p1.x, p2.x) - s.brushSize / 2;
+    const minY = Math.min(p1.y, p2.y) - s.brushSize / 2;
+    const maxX = Math.max(p1.x, p2.x) + s.brushSize / 2;
+    const maxY = Math.max(p1.y, p2.y) + s.brushSize / 2;
+    eng.expandPendingRectByRect(minX, minY, maxX - minX, maxY - minY);
+  }
+}


### PR DESCRIPTION
## Summary
- add Minimal drawing tool rendering simple polylines
- expose Minimal in toolbar and register with engine
- support brush size/color controls for Minimal tool

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c2677d741483249015387070f5ec6d