### PR TITLE
Add smooth brush tool with Catmull-Rom smoothing

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,6 +40,7 @@
         <button class="tool" data-tool="pencil-click" title="Shift+P">鉛筆(オフドラッグ)</button>
         <button class="tool" data-tool="brush" title="B">ブラシ</button>
         <button class="tool" data-tool="minimal">Minimal</button>
+        <button class="tool" data-tool="smooth">Smooth</button>
         <button class="tool" data-tool="eraser" title="E">消しゴム</button>
         <button class="tool" data-tool="eraser-click" title="Shift+E">消しゴム(オフドラッグ)</button>
         <button class="tool" data-tool="eyedropper" title="I">スポイト</button>
@@ -139,6 +140,7 @@
     <script src="src/tools/pencil-click.js"></script>
     <script src="src/tools/brush.js"></script>
     <script src="src/tools/minimal.js"></script>
+    <script src="src/tools/smooth.js"></script>
     <script src="src/tools/eraser.js"></script>
     <script src="src/tools/eraser-click.js"></script>
   <script src="src/tools/quadratic.js"></script>

--- a/src/app.js
+++ b/src/app.js
@@ -44,6 +44,7 @@ export class PaintApp {
     this.engine.register(makePencilClick(this.store));
     this.engine.register(makeBrush(this.store));
     this.engine.register(makeMinimal(this.store));
+    this.engine.register(makeSmooth(this.store));
     this.engine.register(makeEraser(this.store));
     this.engine.register(makeEraserClick(this.store));
     this.engine.register(makeEyedropper(this.store));

--- a/src/gui/tool-props.js
+++ b/src/gui/tool-props.js
@@ -39,6 +39,7 @@ export const toolPropDefs = {
   pencil: [...strokeProps],
   'pencil-click': [...strokeProps],
   brush: [...strokeProps, ...smoothProps],
+  smooth: [...strokeProps],
   minimal: [
     { name: 'brushSize', label: '線幅', type: 'range', min: 1, max: 6, step: 1, default: 4 },
     { name: 'primaryColor', label: '線色', type: 'color', default: '#000000' },

--- a/src/tools/smooth.js
+++ b/src/tools/smooth.js
@@ -1,0 +1,147 @@
+function makeSmooth(store) {
+  const id = 'smooth';
+  let pts = [];
+  let drawing = false;
+
+  return {
+    id,
+    cursor: 'crosshair',
+    previewRect: null,
+    onPointerDown(ctx, ev, eng) {
+      eng.clearSelection();
+      drawing = true;
+      pts = [{ ...ev.img }];
+    },
+    onPointerMove(ctx, ev) {
+      if (!drawing) return;
+      const p = { ...ev.img };
+      const last = pts[pts.length - 1];
+      const dx = p.x - last.x,
+        dy = p.y - last.y;
+      if (dx * dx + dy * dy < 1) return; // 近接点間引き
+      pts.push(p);
+    },
+    onPointerUp(ctx, ev, eng) {
+      if (!drawing) return;
+      drawing = false;
+      pts.push({ ...ev.img });
+      const s = store.getToolState(id);
+      const path = buildSmoothPath(pts, s.brushSize);
+      const r = s.brushSize / 2;
+      let minX = path[0]?.x ?? 0,
+        maxX = minX,
+        minY = path[0]?.y ?? 0,
+        maxY = minY;
+      ctx.save();
+      ctx.fillStyle = s.primaryColor;
+      for (const p of path) {
+        ctx.beginPath();
+        ctx.arc(p.x, p.y, r, 0, Math.PI * 2);
+        ctx.fill();
+        minX = Math.min(minX, p.x);
+        maxX = Math.max(maxX, p.x);
+        minY = Math.min(minY, p.y);
+        maxY = Math.max(maxY, p.y);
+      }
+      ctx.restore();
+      eng.expandPendingRectByRect(minX - r, minY - r, maxX - minX + r * 2, maxY - minY + r * 2);
+      pts = [];
+    },
+    drawPreview(octx) {
+      if (!drawing || pts.length < 2) return;
+      const s = store.getToolState(id);
+      const path = buildSmoothPath(pts, s.brushSize);
+      if (path.length < 2) return;
+      octx.save();
+      octx.lineWidth = s.brushSize;
+      octx.strokeStyle = s.primaryColor;
+      octx.lineCap = 'round';
+      octx.lineJoin = 'round';
+      octx.beginPath();
+      octx.moveTo(path[0].x + 0.5, path[0].y + 0.5);
+      for (let i = 1; i < path.length; i++)
+        octx.lineTo(path[i].x + 0.5, path[i].y + 0.5);
+      octx.stroke();
+      octx.restore();
+    },
+  };
+}
+
+function buildSmoothPath(pts, size) {
+  const smoothed = emaSmooth(pts, 0.3); // EMA α≈0.3
+  const cr = centripetalCRSpline(smoothed, 16); // α=0.5, 分割数16
+  const ds = size / 2; // Δs≈w/2
+  return resampleByDistance(cr, ds);
+}
+
+function emaSmooth(points, alpha) {
+  if (points.length === 0) return [];
+  const out = [{ ...points[0] }];
+  for (let i = 1; i < points.length; i++) {
+    const prev = out[out.length - 1];
+    const p = points[i];
+    out.push({
+      x: alpha * p.x + (1 - alpha) * prev.x,
+      y: alpha * p.y + (1 - alpha) * prev.y,
+    });
+  }
+  return out;
+}
+
+function centripetalCRSpline(pts, seg = 16) {
+  if (pts.length < 2) return pts;
+  const out = [];
+  const alpha = 0.5;
+  for (let i = 0; i < pts.length - 1; i++) {
+    const p0 = pts[i - 1] || pts[i];
+    const p1 = pts[i];
+    const p2 = pts[i + 1];
+    const p3 = pts[i + 2] || p2;
+    const d01 = Math.hypot(p1.x - p0.x, p1.y - p0.y);
+    const d12 = Math.hypot(p2.x - p1.x, p2.y - p1.y);
+    const d23 = Math.hypot(p3.x - p2.x, p3.y - p2.y);
+    const t0 = 0;
+    const t1 = t0 + Math.pow(d01, alpha);
+    const t2 = t1 + Math.pow(d12, alpha);
+    const t3 = t2 + Math.pow(d23, alpha);
+    for (let j = 0; j <= seg; j++) {
+      const t = t1 + ((t2 - t1) * j) / seg;
+      const A1 = lerpPoint(p0, p1, (t1 - t) / (t1 - t0));
+      const A2 = lerpPoint(p1, p2, (t2 - t) / (t2 - t1));
+      const A3 = lerpPoint(p2, p3, (t3 - t) / (t3 - t2));
+      const B1 = lerpPoint(A1, A2, (t2 - t) / (t2 - t0));
+      const B2 = lerpPoint(A2, A3, (t3 - t) / (t3 - t1));
+      out.push(lerpPoint(B1, B2, (t2 - t) / (t2 - t1)));
+    }
+  }
+  return out;
+}
+
+function lerpPoint(a, b, t) {
+  return { x: a.x + (b.x - a.x) * (1 - t), y: a.y + (b.y - a.y) * (1 - t) };
+}
+
+function resampleByDistance(pts, ds) {
+  if (pts.length === 0) return [];
+  const out = [pts[0]];
+  let prev = pts[0];
+  let acc = 0;
+  for (let i = 1; i < pts.length; i++) {
+    let curr = pts[i];
+    let segLen = Math.hypot(curr.x - prev.x, curr.y - prev.y);
+    if (segLen === 0) continue;
+    while (acc + segLen >= ds) {
+      const t = (ds - acc) / segLen;
+      const nx = prev.x + (curr.x - prev.x) * t;
+      const ny = prev.y + (curr.y - prev.y) * t;
+      const np = { x: nx, y: ny };
+      out.push(np);
+      prev = np;
+      segLen = Math.hypot(curr.x - prev.x, curr.y - prev.y);
+      acc = 0;
+    }
+    acc += segLen;
+    prev = curr;
+  }
+  return out;
+}


### PR DESCRIPTION
## Summary
- add smooth brush tool featuring EMA smoothing, centripetal Catmull-Rom interpolation, and arc-length resampling
- expose smooth brush in toolbar and register in application
- add tool properties for smooth brush

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c269333bbc832483004f753266c055