### PR TITLE
Add texture brush tool

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,6 +41,7 @@
         <button class="tool" data-tool="brush" title="B">ブラシ</button>
         <button class="tool" data-tool="minimal">Minimal</button>
         <button class="tool" data-tool="smooth">Smooth</button>
+        <button class="tool" data-tool="texture-brush">Texture</button>
         <button class="tool" data-tool="eraser" title="E">消しゴム</button>
         <button class="tool" data-tool="eraser-click" title="Shift+E">消しゴム(オフドラッグ)</button>
         <button class="tool" data-tool="eyedropper" title="I">スポイト</button>
@@ -141,6 +142,7 @@
     <script src="src/tools/brush.js"></script>
     <script src="src/tools/minimal.js"></script>
     <script src="src/tools/smooth.js"></script>
+    <script src="src/tools/texture-brush.js"></script>
     <script src="src/tools/eraser.js"></script>
     <script src="src/tools/eraser-click.js"></script>
   <script src="src/tools/quadratic.js"></script>

--- a/src/app.js
+++ b/src/app.js
@@ -45,6 +45,7 @@ export class PaintApp {
     this.engine.register(makeBrush(this.store));
     this.engine.register(makeMinimal(this.store));
     this.engine.register(makeSmooth(this.store));
+    this.engine.register(makeTextureBrush(this.store));
     this.engine.register(makeEraser(this.store));
     this.engine.register(makeEraserClick(this.store));
     this.engine.register(makeEyedropper(this.store));

--- a/src/gui/tool-props.js
+++ b/src/gui/tool-props.js
@@ -40,6 +40,7 @@ export const toolPropDefs = {
   'pencil-click': [...strokeProps],
   brush: [...strokeProps, ...smoothProps],
   smooth: [...strokeProps],
+  'texture-brush': [...strokeProps, { name: 'spacingRatio', label: '間隔', type: 'range', min: 0.1, max: 1, step: 0.05, default: 0.4 }],
   minimal: [
     { name: 'brushSize', label: '線幅', type: 'range', min: 1, max: 6, step: 1, default: 4 },
     { name: 'primaryColor', label: '線色', type: 'color', default: '#000000' },

--- a/src/tools/texture-brush.js
+++ b/src/tools/texture-brush.js
@@ -1,0 +1,105 @@
+function makeTextureBrush(store) {
+  const id = 'texture-brush';
+  const texture = createTexture();
+  let drawing = false;
+  let last = null;
+  let acc = 0;
+
+  function stamp(ctx, x, y, angle, s, eng) {
+    const scale = s.brushSize / texture.width;
+    const scatterRange = s.brushSize / 5;
+    const sx = x + gaussianRandom() * scatterRange;
+    const sy = y + gaussianRandom() * scatterRange;
+
+    ctx.save();
+    ctx.translate(sx, sy);
+    ctx.rotate(angle);
+    ctx.scale(scale, scale);
+    ctx.drawImage(texture, -texture.width / 2, -texture.height / 2);
+    ctx.globalCompositeOperation = 'source-in';
+    ctx.fillStyle = s.primaryColor;
+    ctx.fillRect(-texture.width / 2, -texture.height / 2, texture.width, texture.height);
+    ctx.restore();
+
+    const w = texture.width * scale;
+    const h = texture.height * scale;
+    const r = Math.sqrt(w * w + h * h) / 2 + scatterRange;
+    eng.expandPendingRectByRect(sx - r, sy - r, r * 2, r * 2);
+  }
+
+  return {
+    id,
+    cursor: 'crosshair',
+    previewRect: null,
+    onPointerDown(ctx, ev, eng) {
+      eng.clearSelection();
+      drawing = true;
+      last = { ...ev.img };
+      acc = 0;
+      const s = store.getToolState(id);
+      stamp(ctx, last.x, last.y, 0, s, eng);
+    },
+    onPointerMove(ctx, ev, eng) {
+      if (!drawing || !last) return;
+      const p = { ...ev.img };
+      const s = store.getToolState(id);
+      const spacing = Math.max(1, s.brushSize * (s.spacingRatio ?? 0.4));
+      let dx = p.x - last.x;
+      let dy = p.y - last.y;
+      let dist = Math.hypot(dx, dy);
+      let angle = Math.atan2(dy, dx);
+
+      while (acc + dist >= spacing) {
+        const t = (spacing - acc) / dist;
+        const nx = last.x + dx * t;
+        const ny = last.y + dy * t;
+        stamp(ctx, nx, ny, angle, s, eng);
+        last = { x: nx, y: ny };
+        dx = p.x - last.x;
+        dy = p.y - last.y;
+        dist = Math.hypot(dx, dy);
+        angle = Math.atan2(dy, dx);
+        acc = 0;
+      }
+      acc += dist;
+      last = p;
+    },
+    onPointerUp() {
+      drawing = false;
+      last = null;
+      acc = 0;
+    },
+    drawPreview() {},
+  };
+
+  function createTexture() {
+    const cvs = document.createElement('canvas');
+    cvs.width = cvs.height = 64;
+    const tctx = cvs.getContext('2d');
+    const img = tctx.createImageData(64, 64);
+    for (let y = 0; y < 64; y++) {
+      for (let x = 0; x < 64; x++) {
+        const dx = x - 32;
+        const dy = y - 32;
+        if (Math.hypot(dx, dy) <= 32) {
+          const i = (y * 64 + x) * 4;
+          img.data[i] = 255;
+          img.data[i + 1] = 255;
+          img.data[i + 2] = 255;
+          const dist = Math.hypot(dx, dy) / 32;
+          const alpha = (1 - dist) * Math.random() * 255;
+          img.data[i + 3] = alpha;
+        }
+      }
+    }
+    tctx.putImageData(img, 0, 0);
+    return cvs;
+  }
+
+  function gaussianRandom() {
+    let u = 0, v = 0;
+    while (u === 0) u = Math.random();
+    while (v === 0) v = Math.random();
+    return Math.sqrt(-2 * Math.log(u)) * Math.cos(2 * Math.PI * v);
+  }
+}


### PR DESCRIPTION
## Summary
- add texture brush tool that stamps a noisy texture along strokes
- register texture brush with toolbar and tool properties

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c4bb6e87c48324ba1cb02b40b468f7