### PR TITLE
Add SDF stroke drawing tool

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,6 +43,7 @@
         <button class="tool" data-tool="smooth">Smooth</button>
         <button class="tool" data-tool="texture-brush">Texture</button>
         <button class="tool" data-tool="tess-stroke">テッセ</button>
+        <button class="tool" data-tool="sdf-stroke">SDF</button>
         <button class="tool" data-tool="eraser" title="E">消しゴム</button>
         <button class="tool" data-tool="eraser-click" title="Shift+E">消しゴム(オフドラッグ)</button>
         <button class="tool" data-tool="eyedropper" title="I">スポイト</button>
@@ -145,6 +146,7 @@
     <script src="src/tools/smooth.js"></script>
     <script src="src/tools/texture-brush.js"></script>
     <script src="src/tools/tessellated-stroke.js"></script>
+    <script src="src/tools/sdf-stroke.js"></script>
     <script src="src/tools/eraser.js"></script>
     <script src="src/tools/eraser-click.js"></script>
   <script src="src/tools/quadratic.js"></script>

--- a/src/app.js
+++ b/src/app.js
@@ -47,6 +47,7 @@ export class PaintApp {
     this.engine.register(makeSmooth(this.store));
     this.engine.register(makeTextureBrush(this.store));
     this.engine.register(makeTessellatedStroke(this.store));
+    this.engine.register(makeSdfStroke(this.store));
     this.engine.register(makeEraser(this.store));
     this.engine.register(makeEraserClick(this.store));
     this.engine.register(makeEyedropper(this.store));

--- a/src/tools/sdf-stroke.js
+++ b/src/tools/sdf-stroke.js
@@ -1,0 +1,93 @@
+function makeSdfStroke(store) {
+  const id = 'sdf-stroke';
+  const pts = [];
+  let drawing = false;
+
+  return {
+    id,
+    cursor: 'crosshair',
+    previewRect: null,
+
+    onPointerDown(ctx, ev, eng) {
+      eng.clearSelection();
+      eng.beginStrokeSnapshot();
+      drawing = true;
+      pts.length = 0;
+      pts.push({ ...ev.img });
+      const s = store.getToolState(id);
+      const rect = drawSegment(ctx, ev.img, ev.img, s);
+      eng.expandPendingRectByRect(rect.x, rect.y, rect.w, rect.h);
+    },
+
+    onPointerMove(ctx, ev, eng) {
+      if (!drawing) return;
+      const p = { ...ev.img };
+      const s = store.getToolState(id);
+      const rect = drawSegment(ctx, pts[pts.length - 1], p, s);
+      eng.expandPendingRectByRect(rect.x, rect.y, rect.w, rect.h);
+      pts.push(p);
+    },
+
+    onPointerUp(ctx, ev, eng) {
+      if (!drawing) return;
+      drawing = false;
+      pts.length = 0;
+    },
+
+    drawPreview() {},
+  };
+
+  function drawSegment(ctx, p0, p1, s) {
+    const r = s.brushSize / 2;
+    const aa = 1;
+    const minX = Math.floor(Math.min(p0.x, p1.x) - r - aa);
+    const minY = Math.floor(Math.min(p0.y, p1.y) - r - aa);
+    const maxX = Math.ceil(Math.max(p0.x, p1.x) + r + aa);
+    const maxY = Math.ceil(Math.max(p0.y, p1.y) + r + aa);
+    const w = maxX - minX;
+    const h = maxY - minY;
+    const img = ctx.getImageData(minX, minY, w, h);
+    const data = img.data;
+    const col = hexToRgb(s.primaryColor);
+
+    for (let y = 0; y < h; y++) {
+      for (let x = 0; x < w; x++) {
+        const px = minX + x + 0.5;
+        const py = minY + y + 0.5;
+        const d = pointSegmentDistance(px, py, p0.x, p0.y, p1.x, p1.y);
+        const t = (r + aa - d) / (aa * 2);
+        if (t <= 0) continue;
+        const cov = t >= 1 ? 1 : t * t * (3 - 2 * t);
+        if (cov <= 0) continue;
+        const idx = (y * w + x) * 4;
+        const inv = 1 - cov;
+        data[idx] = col.r * cov + data[idx] * inv;
+        data[idx + 1] = col.g * cov + data[idx + 1] * inv;
+        data[idx + 2] = col.b * cov + data[idx + 2] * inv;
+        data[idx + 3] = 255 * cov + data[idx + 3] * inv;
+      }
+    }
+    ctx.putImageData(img, minX, minY);
+    return { x: minX, y: minY, w, h };
+  }
+
+  function pointSegmentDistance(px, py, x0, y0, x1, y1) {
+    const dx = x1 - x0;
+    const dy = y1 - y0;
+    const l2 = dx * dx + dy * dy;
+    if (!l2) return Math.hypot(px - x0, py - y0);
+    let t = ((px - x0) * dx + (py - y0) * dy) / l2;
+    t = Math.max(0, Math.min(1, t));
+    const projX = x0 + t * dx;
+    const projY = y0 + t * dy;
+    return Math.hypot(px - projX, py - projY);
+  }
+
+  function hexToRgb(hex) {
+    const n = hex.startsWith('#') ? hex.slice(1) : hex;
+    const v = parseInt(n.length === 3 ? n.replace(/(.)/g, '$1$1') : n, 16);
+    return { r: (v >> 16) & 255, g: (v >> 8) & 255, b: v & 255 };
+  }
+}
+
+window.makeSdfStroke = makeSdfStroke;


### PR DESCRIPTION
## Summary
- add SDF stroke tool for smooth anti-aliased strokes
- register tool and expose SDF button left of eraser in toolbar

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c4bed93fec8324a58be75a6bfd937f