### PR TITLE
Add watercolor tool with diffusion simulation

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,6 +44,7 @@
         <button class="tool" data-tool="texture-brush">Texture</button>
         <button class="tool" data-tool="tess-stroke">テッセ</button>
         <button class="tool" data-tool="sdf-stroke">SDF</button>
+        <button class="tool" data-tool="watercolor" title="W">水彩</button>
         <button class="tool" data-tool="eraser" title="E">消しゴム</button>
         <button class="tool" data-tool="eraser-click" title="Shift+E">消しゴム(オフドラッグ)</button>
         <button class="tool" data-tool="eyedropper" title="I">スポイト</button>
@@ -147,6 +148,7 @@
     <script src="src/tools/texture-brush.js"></script>
     <script src="src/tools/tessellated-stroke.js"></script>
     <script src="src/tools/sdf-stroke.js"></script>
+    <script src="src/tools/watercolor.js"></script>
     <script src="src/tools/eraser.js"></script>
     <script src="src/tools/eraser-click.js"></script>
   <script src="src/tools/quadratic.js"></script>

--- a/src/app.js
+++ b/src/app.js
@@ -48,6 +48,7 @@ export class PaintApp {
     this.engine.register(makeTextureBrush(this.store));
     this.engine.register(makeTessellatedStroke(this.store));
     this.engine.register(makeSdfStroke(this.store));
+    this.engine.register(makeWatercolor(this.store));
     this.engine.register(makeEraser(this.store));
     this.engine.register(makeEraserClick(this.store));
     this.engine.register(makeEyedropper(this.store));

--- a/src/core/store.js
+++ b/src/core/store.js
@@ -69,4 +69,6 @@ export const toolDefaults = {
   nurbsWeight: 1,
   fontFamily: 'system-ui, sans-serif',
   fontSize: 24,
+  diffusion: 0.1,
+  evaporation: 0.02,
 };

--- a/src/gui/tool-props.js
+++ b/src/gui/tool-props.js
@@ -41,6 +41,11 @@ export const toolPropDefs = {
   brush: [...strokeProps, ...smoothProps],
   smooth: [...strokeProps],
   'texture-brush': [...strokeProps, { name: 'spacingRatio', label: '間隔', type: 'range', min: 0.1, max: 1, step: 0.05, default: 0.4 }],
+  watercolor: [
+    ...strokeProps,
+    { name: 'diffusion', label: '拡散D', type: 'range', min: 0.05, max: 0.2, step: 0.01, default: 0.1 },
+    { name: 'evaporation', label: '蒸発E', type: 'range', min: 0.01, max: 0.05, step: 0.01, default: 0.02 },
+  ],
   'tess-stroke': [...strokeProps],
   minimal: [
     { name: 'brushSize', label: '線幅', type: 'range', min: 1, max: 6, step: 1, default: 4 },

--- a/src/tools/watercolor.js
+++ b/src/tools/watercolor.js
@@ -1,0 +1,114 @@
+function makeWatercolor(store) {
+  const id = 'watercolor';
+  let drawing = false;
+  let ctxRef = null;
+  let engRef = null;
+  const wetCanvas = document.createElement('canvas');
+  let wetCtx = wetCanvas.getContext('2d');
+  let running = false;
+  let hasWet = false;
+
+  function ensureCanvas(ctx) {
+    if (wetCanvas.width !== ctx.canvas.width || wetCanvas.height !== ctx.canvas.height) {
+      wetCanvas.width = ctx.canvas.width;
+      wetCanvas.height = ctx.canvas.height;
+      wetCtx = wetCanvas.getContext('2d');
+    }
+  }
+
+  function stamp(x, y, size, color) {
+    wetCtx.save();
+    wetCtx.fillStyle = color;
+    wetCtx.beginPath();
+    wetCtx.arc(x, y, size / 2, 0, Math.PI * 2);
+    wetCtx.fill();
+    wetCtx.restore();
+    hasWet = true;
+  }
+
+  function step() {
+    if (!ctxRef || !hasWet) { running = false; return; }
+    const { diffusion = 0.1, evaporation = 0.02 } = store.getToolState(id);
+    const D = parseFloat(diffusion);
+    const E = parseFloat(evaporation);
+    const absorption = 0.05;
+    const w = wetCanvas.width;
+    const h = wetCanvas.height;
+    const img = wetCtx.getImageData(0, 0, w, h);
+    const src = img.data;
+    const dst = new Uint8ClampedArray(src.length);
+    let maxA = 0;
+
+    for (let y = 0; y < h; y++) {
+      for (let x = 0; x < w; x++) {
+        const idx = (y * w + x) * 4;
+        for (let c = 0; c < 4; c++) {
+          const center = src[idx + c];
+          const up = src[idx + (y > 0 ? -w * 4 : 0) + c];
+          const down = src[idx + (y < h - 1 ? w * 4 : 0) + c];
+          const left = src[idx + (x > 0 ? -4 : 0) + c];
+          const right = src[idx + (x < w - 1 ? 4 : 0) + c];
+          let val = center + D * (up + down + left + right - 4 * center);
+          if (c === 3) {
+            val *= 1 - E;
+            maxA = Math.max(maxA, val);
+          }
+          dst[idx + c] = Math.max(0, Math.min(255, val));
+        }
+      }
+    }
+
+    img.data.set(dst);
+    wetCtx.putImageData(img, 0, 0);
+
+    ctxRef.save();
+    ctxRef.globalAlpha = absorption;
+    ctxRef.drawImage(wetCanvas, 0, 0);
+    ctxRef.restore();
+
+    wetCtx.save();
+    wetCtx.globalCompositeOperation = 'destination-out';
+    wetCtx.globalAlpha = absorption;
+    wetCtx.drawImage(wetCanvas, 0, 0);
+    wetCtx.restore();
+
+    engRef?.expandPendingRectByRect(0, 0, w, h);
+
+    if (maxA > 0) {
+      requestAnimationFrame(step);
+    } else {
+      hasWet = false;
+      running = false;
+      engRef?.finishStrokeToHistory();
+    }
+  }
+
+  return {
+    id,
+    cursor: 'crosshair',
+    previewRect: null,
+    onPointerDown(ctx, ev, eng) {
+      eng.clearSelection();
+      eng.beginStrokeSnapshot?.();
+      ensureCanvas(ctx);
+      ctxRef = ctx;
+      engRef = eng;
+      drawing = true;
+      const s = store.getToolState(id);
+      stamp(ev.img.x, ev.img.y, s.brushSize, s.primaryColor);
+      if (!running) {
+        running = true;
+        requestAnimationFrame(step);
+      }
+    },
+    onPointerMove(ctx, ev) {
+      if (!drawing) return;
+      const s = store.getToolState(id);
+      stamp(ev.img.x, ev.img.y, s.brushSize, s.primaryColor);
+    },
+    onPointerUp() {
+      drawing = false;
+    },
+    drawPreview() {},
+  };
+}


### PR DESCRIPTION
## Summary
- add watercolor tool simulating diffusion, evaporation, and absorption
- expose diffusion and evaporation parameters in tool props
- add toolbar button and register watercolor tool

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c4c0e785ec8324bea3f214039ca89c