### PR TITLE
feat: add vector keep tool

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,6 +46,7 @@
         <button class="tool" data-tool="sdf-stroke">SDF</button>
         <button class="tool" data-tool="watercolor" title="W">水彩</button>
         <button class="tool" data-tool="preview-refine">二段</button>
+        <button class="tool" data-tool="vector-keep" title="K">ベクタ</button>
         <button class="tool" data-tool="eraser" title="E">消しゴム</button>
         <button class="tool" data-tool="eraser-click" title="Shift+E">消しゴム(オフドラッグ)</button>
         <button class="tool" data-tool="eyedropper" title="I">スポイト</button>
@@ -151,6 +152,7 @@
     <script src="src/tools/sdf-stroke.js"></script>
     <script src="src/tools/watercolor.js"></script>
     <script src="src/tools/preview-refine.js"></script>
+    <script src="src/tools/vector-keep.js"></script>
     <script src="src/tools/eraser.js"></script>
     <script src="src/tools/eraser-click.js"></script>
   <script src="src/tools/quadratic.js"></script>

--- a/src/app.js
+++ b/src/app.js
@@ -50,6 +50,7 @@ export class PaintApp {
     this.engine.register(makeSdfStroke(this.store));
     this.engine.register(makeWatercolor(this.store));
     this.engine.register(makePreviewRefine(this.store));
+    this.engine.register(makeVectorKeep(this.store));
     this.engine.register(makeEraser(this.store));
     this.engine.register(makeEraserClick(this.store));
     this.engine.register(makeEyedropper(this.store));

--- a/src/gui/toolbar.js
+++ b/src/gui/toolbar.js
@@ -94,6 +94,7 @@ function initKeyboardShortcuts() {
       'KeyS': 'sector',
       'KeyU': 'catmull',
       'KeyN': 'nurbs',
+      'KeyK': 'vector-keep',
       'KeyH': 'freehand'
     };
 

--- a/src/tools/vector-keep.js
+++ b/src/tools/vector-keep.js
@@ -1,0 +1,54 @@
+function makeVectorKeep(store) {
+  const id = 'vector-keep';
+  let drawing = false,
+    last = null,
+    path = [];
+  return {
+    id,
+    cursor: 'crosshair',
+    onPointerDown(ctx, ev, eng) {
+      eng.clearSelection();
+      eng.beginStrokeSnapshot?.();
+      drawing = true;
+      last = null;
+      path = [];
+      eng.expandPendingRect(ev.img.x, ev.img.y, store.getToolState(id).brushSize);
+      stroke(ctx, ev.img);
+    },
+    onPointerMove(ctx, ev, eng) {
+      if (!drawing) return;
+      eng.expandPendingRect(ev.img.x, ev.img.y, store.getToolState(id).brushSize);
+      stroke(ctx, ev.img);
+    },
+    onPointerUp(ctx) {
+      if (!drawing) return;
+      drawing = false;
+      last = null;
+      const s = store.getToolState(id);
+      const vectors = s.vectors || [];
+      vectors.push({
+        points: path.map(p => ({ x: p.x, y: p.y })),
+        color: s.primaryColor,
+        width: s.brushSize,
+      });
+      store.setToolState(id, { vectors });
+      path = [];
+    },
+  };
+  function stroke(ctx, img) {
+    const s = store.getToolState(id);
+    ctx.save();
+    ctx.lineCap = 'round';
+    ctx.lineJoin = 'round';
+    ctx.strokeStyle = s.primaryColor;
+    ctx.lineWidth = s.brushSize;
+    ctx.beginPath();
+    if (last) ctx.moveTo(last.x + 0.01, last.y + 0.01);
+    else ctx.moveTo(img.x + 0.01, img.y + 0.01);
+    ctx.lineTo(img.x + 0.01, img.y + 0.01);
+    ctx.stroke();
+    ctx.restore();
+    last = { x: img.x, y: img.y };
+    path.push({ x: img.x, y: img.y });
+  }
+}


### PR DESCRIPTION
## Summary
- add Vector Keep drawing tool and toolbar button left of eraser
- register tool with keyboard shortcut `K`

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c4c330ad1883249e1db167627e560e