### PR TITLE
Add bristle brush tool

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,6 +49,7 @@
         <button class="tool" data-tool="vector-keep" title="K">ベクタ</button>
         <button class="tool" data-tool="calligraphy" title="C">カリグラフィ</button>
         <button class="tool" data-tool="ribbon">リボン</button>
+        <button class="tool" data-tool="bristle">多毛筆</button>
         <button class="tool" data-tool="eraser" title="E">消しゴム</button>
         <button class="tool" data-tool="eraser-click" title="Shift+E">消しゴム(オフドラッグ)</button>
         <button class="tool" data-tool="eyedropper" title="I">スポイト</button>
@@ -157,6 +158,7 @@
     <script src="src/tools/vector-keep.js"></script>
     <script src="src/tools/calligraphy.js"></script>
     <script src="src/tools/ribbon.js"></script>
+    <script src="src/tools/bristle.js"></script>
     <script src="src/tools/eraser.js"></script>
     <script src="src/tools/eraser-click.js"></script>
   <script src="src/tools/quadratic.js"></script>

--- a/src/app.js
+++ b/src/app.js
@@ -53,6 +53,7 @@ export class PaintApp {
     this.engine.register(makeVectorKeep(this.store));
     this.engine.register(makeCalligraphy(this.store));
     this.engine.register(makeRibbon(this.store));
+    this.engine.register(makeBristle(this.store));
     this.engine.register(makeEraser(this.store));
     this.engine.register(makeEraserClick(this.store));
     this.engine.register(makeEyedropper(this.store));

--- a/src/gui/tool-props.js
+++ b/src/gui/tool-props.js
@@ -56,6 +56,10 @@ export const toolPropDefs = {
       { name: 'penAngle', label: '角度', type: 'range', min: 0, max: 180, step: 1, default: 45 },
       { name: 'kappa', label: '縦横比', type: 'range', min: 1.5, max: 3, step: 0.1, default: 2 },
     ],
+    bristle: [
+      { name: 'brushSize', label: '線幅', type: 'range', min: 1, max: 64, step: 1, default: 8 },
+      { name: 'count', label: '本数', type: 'range', min: 4, max: 12, step: 1, default: 8 },
+    ],
     eraser: [{ name: 'brushSize', label: 'サイズ', type: 'range', min: 1, max: 64, step: 1, default: 4 }],
     'eraser-click': [{ name: 'brushSize', label: 'サイズ', type: 'range', min: 1, max: 64, step: 1, default: 4 }],
     bucket: [{ name: 'primaryColor', label: '色', type: 'color', default: '#000000' }],

--- a/src/tools/bristle.js
+++ b/src/tools/bristle.js
@@ -1,0 +1,95 @@
+// Simple bristle brush: draws multiple thin strokes with random offsets
+function makeBristle(store) {
+  const id = 'bristle';
+  let drawing = false;
+  let last = null;
+  let hairs = [];
+
+  function randn() {
+    // Box-Muller transform
+    let u = 0, v = 0;
+    while (u === 0) u = Math.random();
+    while (v === 0) v = Math.random();
+    return Math.sqrt(-2.0 * Math.log(u)) * Math.cos(2.0 * Math.PI * v);
+  }
+
+  return {
+    id,
+    cursor: 'crosshair',
+    previewRect: null,
+
+    onPointerDown(ctx, ev, eng) {
+      eng.clearSelection();
+      drawing = true;
+      last = { ...ev.img };
+
+      const s = store.getToolState(id);
+      const n = s.count || 8;
+      const sigma = s.brushSize * 0.3;
+      hairs = [];
+      for (let i = 0; i < n; i++) {
+        const offx = randn() * sigma;
+        const offy = randn() * sigma;
+        const w = s.brushSize * (0.5 + Math.random() * 0.3);
+        hairs.push({ offx, offy, w });
+        ctx.save();
+        ctx.lineCap = 'round';
+        ctx.lineJoin = 'round';
+        ctx.strokeStyle = s.primaryColor;
+        ctx.lineWidth = w;
+        ctx.beginPath();
+        ctx.moveTo(last.x + offx + 0.5, last.y + offy + 0.5);
+        ctx.lineTo(last.x + offx + 0.5, last.y + offy + 0.5);
+        ctx.stroke();
+        ctx.restore();
+        eng.expandPendingRectByRect(
+          last.x + offx - w,
+          last.y + offy - w,
+          w * 2,
+          w * 2
+        );
+      }
+    },
+
+    onPointerMove(ctx, ev, eng) {
+      if (!drawing || !last) return;
+      const p = { ...ev.img };
+      const s = store.getToolState(id);
+      hairs.forEach(h => {
+        const sx = last.x + h.offx;
+        const sy = last.y + h.offy;
+        const ex = p.x + h.offx;
+        const ey = p.y + h.offy;
+        ctx.save();
+        ctx.lineCap = 'round';
+        ctx.lineJoin = 'round';
+        ctx.strokeStyle = s.primaryColor;
+        ctx.lineWidth = h.w;
+        ctx.beginPath();
+        ctx.moveTo(sx + 0.5, sy + 0.5);
+        ctx.lineTo(ex + 0.5, ey + 0.5);
+        ctx.stroke();
+        ctx.restore();
+        const minX = Math.min(sx, ex);
+        const minY = Math.min(sy, ey);
+        const segW = Math.abs(ex - sx);
+        const segH = Math.abs(ey - sy);
+        eng.expandPendingRectByRect(
+          minX - h.w,
+          minY - h.w,
+          segW + h.w * 2,
+          segH + h.w * 2
+        );
+      });
+      last = p;
+    },
+
+    onPointerUp() {
+      drawing = false;
+      last = null;
+      hairs = [];
+    },
+
+    drawPreview() {},
+  };
+}


### PR DESCRIPTION
## Summary
- add multi-hair "Bristle" brush tool with random offset strokes
- register Bristle tool and expose adjustable count/size options
- add toolbar button and script for Bristle brush before eraser

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c5362e67788324a517bcdbed8b2078