### PR TITLE
Add airbrush drawing tool

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,6 +50,7 @@
         <button class="tool" data-tool="calligraphy" title="C">カリグラフィ</button>
         <button class="tool" data-tool="ribbon">リボン</button>
         <button class="tool" data-tool="bristle">多毛筆</button>
+        <button class="tool" data-tool="airbrush">エアブラシ</button>
         <button class="tool" data-tool="eraser" title="E">消しゴム</button>
         <button class="tool" data-tool="eraser-click" title="Shift+E">消しゴム(オフドラッグ)</button>
         <button class="tool" data-tool="eyedropper" title="I">スポイト</button>
@@ -159,6 +160,7 @@
     <script src="src/tools/calligraphy.js"></script>
     <script src="src/tools/ribbon.js"></script>
     <script src="src/tools/bristle.js"></script>
+    <script src="src/tools/airbrush.js"></script>
     <script src="src/tools/eraser.js"></script>
     <script src="src/tools/eraser-click.js"></script>
   <script src="src/tools/quadratic.js"></script>

--- a/src/app.js
+++ b/src/app.js
@@ -54,6 +54,7 @@ export class PaintApp {
     this.engine.register(makeCalligraphy(this.store));
     this.engine.register(makeRibbon(this.store));
     this.engine.register(makeBristle(this.store));
+    this.engine.register(makeAirbrush(this.store));
     this.engine.register(makeEraser(this.store));
     this.engine.register(makeEraserClick(this.store));
     this.engine.register(makeEyedropper(this.store));

--- a/src/tools/airbrush.js
+++ b/src/tools/airbrush.js
@@ -1,0 +1,69 @@
+function makeAirbrush(store) {
+  const id = 'airbrush';
+  let drawing = false;
+  let last = null;
+  const spacing = 4; // Δs: spacing between sprays in pixels
+  const rate = 50; // λ: particles per step
+
+  function spray(ctx, p, eng) {
+    const s = store.getToolState(id);
+    const radius = s.brushSize;
+    ctx.save();
+    ctx.fillStyle = s.primaryColor;
+    for (let i = 0; i < rate; i++) {
+      const theta = Math.random() * Math.PI * 2;
+      const r = Math.random() * radius;
+      const x = p.x + Math.cos(theta) * r;
+      const y = p.y + Math.sin(theta) * r;
+      const size = 1 + Math.random() * 2; // 粒径1〜3px
+      const alpha = 1 - r / radius; // 線形減衰
+      ctx.globalAlpha = alpha;
+      ctx.beginPath();
+      ctx.arc(x, y, size, 0, Math.PI * 2);
+      ctx.fill();
+    }
+    ctx.restore();
+    // 通知: エアブラシ半径のAABBを拡張
+    eng.expandPendingRectByRect(
+      p.x - radius - 3,
+      p.y - radius - 3,
+      (radius + 3) * 2,
+      (radius + 3) * 2,
+    );
+  }
+
+  return {
+    id,
+    cursor: 'crosshair',
+    onPointerDown(ctx, ev, eng) {
+      eng.clearSelection();
+      eng.beginStrokeSnapshot?.();
+      drawing = true;
+      last = { ...ev.img };
+      spray(ctx, last, eng);
+    },
+    onPointerMove(ctx, ev, eng) {
+      if (!drawing || !last) return;
+      const p = { ...ev.img };
+      const dx = p.x - last.x;
+      const dy = p.y - last.y;
+      const dist = Math.hypot(dx, dy);
+      const steps = Math.floor(dist / spacing);
+      if (steps === 0) {
+        spray(ctx, p, eng);
+      } else {
+        for (let i = 1; i <= steps; i++) {
+          const t = i / steps;
+          const cx = last.x + dx * t;
+          const cy = last.y + dy * t;
+          spray(ctx, { x: cx, y: cy }, eng);
+        }
+      }
+      last = p;
+    },
+    onPointerUp() {
+      drawing = false;
+      last = null;
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- implement new airbrush tool that sprays particles with soft falloff
- register airbrush tool and expose button left of eraser in toolbar

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c53836f73c8324b40510e674e77daf