### PR TITLE
Add scatter decal drawing tool

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,6 +51,7 @@
         <button class="tool" data-tool="ribbon">リボン</button>
         <button class="tool" data-tool="bristle">多毛筆</button>
         <button class="tool" data-tool="airbrush">エアブラシ</button>
+        <button class="tool" data-tool="scatter">散布</button>
         <button class="tool" data-tool="eraser" title="E">消しゴム</button>
         <button class="tool" data-tool="eraser-click" title="Shift+E">消しゴム(オフドラッグ)</button>
         <button class="tool" data-tool="eyedropper" title="I">スポイト</button>
@@ -161,6 +162,7 @@
     <script src="src/tools/ribbon.js"></script>
     <script src="src/tools/bristle.js"></script>
     <script src="src/tools/airbrush.js"></script>
+    <script src="src/tools/scatter.js"></script>
     <script src="src/tools/eraser.js"></script>
     <script src="src/tools/eraser-click.js"></script>
   <script src="src/tools/quadratic.js"></script>

--- a/src/app.js
+++ b/src/app.js
@@ -55,6 +55,7 @@ export class PaintApp {
     this.engine.register(makeRibbon(this.store));
     this.engine.register(makeBristle(this.store));
     this.engine.register(makeAirbrush(this.store));
+    this.engine.register(makeScatter(this.store));
     this.engine.register(makeEraser(this.store));
     this.engine.register(makeEraserClick(this.store));
     this.engine.register(makeEyedropper(this.store));

--- a/src/gui/tool-props.js
+++ b/src/gui/tool-props.js
@@ -60,6 +60,7 @@ export const toolPropDefs = {
       { name: 'brushSize', label: '線幅', type: 'range', min: 1, max: 64, step: 1, default: 8 },
       { name: 'count', label: '本数', type: 'range', min: 4, max: 12, step: 1, default: 8 },
     ],
+    scatter: [...strokeProps],
     eraser: [{ name: 'brushSize', label: 'サイズ', type: 'range', min: 1, max: 64, step: 1, default: 4 }],
     'eraser-click': [{ name: 'brushSize', label: 'サイズ', type: 'range', min: 1, max: 64, step: 1, default: 4 }],
     bucket: [{ name: 'primaryColor', label: '色', type: 'color', default: '#000000' }],

--- a/src/gui/toolbar.js
+++ b/src/gui/toolbar.js
@@ -88,6 +88,7 @@ function initKeyboardShortcuts() {
       'KeyL': 'line',
       'KeyR': 'rect',
       'KeyO': 'ellipse',
+      'KeyD': 'scatter',
       'KeyQ': 'quad',
       'KeyC': 'cubic',
       'KeyA': 'arc',

--- a/src/tools/scatter.js
+++ b/src/tools/scatter.js
@@ -1,0 +1,112 @@
+function makeScatter(store) {
+  const id = 'scatter';
+  let drawing = false;
+  let last = null;
+  let acc = 0;
+  let nextSpacing = 0;
+  let prob = 0.5;
+
+  function randSpacing(s) {
+    const base = s.brushSize || 1;
+    return base * (0.8 + Math.random() * 0.4);
+  }
+
+  function randProb() {
+    return 0.3 + Math.random() * 0.5;
+  }
+
+  function randScale() {
+    return 0.7 + Math.random() * 0.6;
+  }
+
+  function randRotation() {
+    const deg = 20 + Math.random() * 20;
+    const sign = Math.random() < 0.5 ? -1 : 1;
+    return (deg * sign * Math.PI) / 180;
+  }
+
+  function randJitter(size) {
+    return (Math.random() - 0.5) * size * 0.3;
+  }
+
+  function stamp(ctx, x, y, s, eng) {
+    if (Math.random() > prob) return;
+    const size = s.brushSize || 0;
+    if (size <= 0) return;
+    const sc = randScale();
+    const rot = randRotation();
+    const jx = randJitter(size);
+    const jy = randJitter(size);
+    const r = (size * sc) / 2 + Math.max(Math.abs(jx), Math.abs(jy));
+
+    ctx.save();
+    ctx.translate(x + jx, y + jy);
+    ctx.rotate(rot);
+    ctx.scale(sc, sc);
+    ctx.fillStyle = s.primaryColor;
+    ctx.beginPath();
+    const rad = size / 2;
+    ctx.moveTo(0, -rad);
+    ctx.bezierCurveTo(rad, -rad / 2, rad, rad / 2, 0, rad);
+    ctx.bezierCurveTo(-rad, rad / 2, -rad, -rad / 2, 0, -rad);
+    ctx.fill();
+    ctx.restore();
+
+    eng.expandPendingRectByRect(x - r, y - r, r * 2, r * 2);
+  }
+
+  return {
+    id,
+    cursor: 'crosshair',
+    previewRect: null,
+    onPointerDown(ctx, ev, eng) {
+      eng.clearSelection();
+      drawing = true;
+      last = { ...ev.img };
+      acc = 0;
+      const s = store.getToolState(id);
+      prob = randProb();
+      nextSpacing = randSpacing(s);
+      stamp(ctx, last.x, last.y, s, eng);
+    },
+    onPointerMove(ctx, ev, eng) {
+      if (!drawing || !last) return;
+      const p = { ...ev.img };
+      const s = store.getToolState(id);
+      const EPS = 1e-6;
+      let dx = p.x - last.x;
+      let dy = p.y - last.y;
+      let dist = Math.hypot(dx, dy);
+      if (dist < EPS) {
+        acc += dist;
+        last = p;
+        return;
+      }
+      while (acc + dist >= nextSpacing) {
+        const t = (nextSpacing - acc) / dist;
+        const nx = last.x + dx * t;
+        const ny = last.y + dy * t;
+        stamp(ctx, nx, ny, s, eng);
+        last = { x: nx, y: ny };
+        dx = p.x - last.x;
+        dy = p.y - last.y;
+        dist = Math.hypot(dx, dy);
+        nextSpacing = randSpacing(s);
+        acc = 0;
+        if (dist < EPS) break;
+      }
+      acc += dist;
+      last = p;
+    },
+    onPointerUp(ctx, ev, eng) {
+      if (!drawing) return;
+      drawing = false;
+      const s = store.getToolState(id);
+      const p = { ...ev.img };
+      stamp(ctx, p.x, p.y, s, eng);
+      last = null;
+      acc = 0;
+    },
+    drawPreview() {},
+  };
+}


### PR DESCRIPTION
## Summary
- add scatter decal tool with randomized spacing and stamping
- provide toolbar button left of eraser and keyboard shortcut D
- register tool and expose properties panel options

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c53a9ec4f483248ae89808cf3140ed