### PR TITLE
Add smudge tool button

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,6 +52,7 @@
         <button class="tool" data-tool="bristle">多毛筆</button>
         <button class="tool" data-tool="airbrush">エアブラシ</button>
         <button class="tool" data-tool="scatter">散布</button>
+        <button class="tool" data-tool="smudge">スマッジ</button>
         <button class="tool" data-tool="eraser" title="E">消しゴム</button>
         <button class="tool" data-tool="eraser-click" title="Shift+E">消しゴム(オフドラッグ)</button>
         <button class="tool" data-tool="eyedropper" title="I">スポイト</button>
@@ -163,6 +164,7 @@
     <script src="src/tools/bristle.js"></script>
     <script src="src/tools/airbrush.js"></script>
     <script src="src/tools/scatter.js"></script>
+    <script src="src/tools/smudge.js"></script>
     <script src="src/tools/eraser.js"></script>
     <script src="src/tools/eraser-click.js"></script>
   <script src="src/tools/quadratic.js"></script>

--- a/src/app.js
+++ b/src/app.js
@@ -56,6 +56,14 @@ export class PaintApp {
     this.engine.register(makeBristle(this.store));
     this.engine.register(makeAirbrush(this.store));
     this.engine.register(makeScatter(this.store));
+    this.engine.register(makeSmudge(this.store));
+    this.store.setToolState('smudge', {
+      radius: 16,
+      strength: 0.5,
+      dirMode: 'tangent',
+      angle: 0,
+      spacingRatio: 0.5,
+    });
     this.engine.register(makeEraser(this.store));
     this.engine.register(makeEraserClick(this.store));
     this.engine.register(makeEyedropper(this.store));

--- a/src/gui/tool-props.js
+++ b/src/gui/tool-props.js
@@ -61,6 +61,22 @@ export const toolPropDefs = {
       { name: 'count', label: '本数', type: 'range', min: 4, max: 12, step: 1, default: 8 },
     ],
     scatter: [...strokeProps],
+    smudge: [
+      { name: 'radius', label: 'サイズ', type: 'range', min: 1, max: 64, step: 1, default: 16 },
+      { name: 'strength', label: '強さ', type: 'range', min: 0, max: 1, step: 0.05, default: 0.5 },
+      {
+        name: 'dirMode',
+        label: '方向',
+        type: 'select',
+        options: [
+          { value: 'tangent', label: '接線' },
+          { value: 'angle', label: '角度指定' },
+        ],
+        default: 'tangent',
+      },
+      { name: 'angle', label: '角度', type: 'range', min: -180, max: 180, step: 1, default: 0 },
+      { name: 'spacingRatio', label: '間隔', type: 'range', min: 0.1, max: 1, step: 0.05, default: 0.5 },
+    ],
     eraser: [{ name: 'brushSize', label: 'サイズ', type: 'range', min: 1, max: 64, step: 1, default: 4 }],
     'eraser-click': [{ name: 'brushSize', label: 'サイズ', type: 'range', min: 1, max: 64, step: 1, default: 4 }],
     bucket: [{ name: 'primaryColor', label: '色', type: 'color', default: '#000000' }],

--- a/src/gui/toolbar.js
+++ b/src/gui/toolbar.js
@@ -89,6 +89,7 @@ function initKeyboardShortcuts() {
       'KeyR': 'rect',
       'KeyO': 'ellipse',
       'KeyD': 'scatter',
+      'KeyG': 'smudge',
       'KeyQ': 'quad',
       'KeyC': 'cubic',
       'KeyA': 'arc',


### PR DESCRIPTION
## Summary
- add Smudge tool button before Eraser
- load smudge tool script and register defaults
- expose smudge tool parameters and shortcut key

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c547eeb2c48324bb041753a4207ed7