### PR TITLE
Add buttons for extra brushes and expose controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,6 +53,9 @@
         <button class="tool" data-tool="airbrush">エアブラシ</button>
         <button class="tool" data-tool="scatter">散布</button>
         <button class="tool" data-tool="smudge">スマッジ</button>
+        <button class="tool" data-tool="aa-line-brush">AA線</button>
+        <button class="tool" data-tool="pixel-brush">ピクセル筆</button>
+        <button class="tool" data-tool="blur-brush">ぼかし</button>
         <button class="tool" data-tool="eraser" title="E">消しゴム</button>
         <button class="tool" data-tool="eraser-click" title="Shift+E">消しゴム(オフドラッグ)</button>
         <button class="tool" data-tool="eyedropper" title="I">スポイト</button>
@@ -165,6 +168,9 @@
     <script src="src/tools/airbrush.js"></script>
     <script src="src/tools/scatter.js"></script>
     <script src="src/tools/smudge.js"></script>
+    <script src="src/tools/aa_line_brush.js"></script>
+    <script src="src/tools/pixel_brush.js"></script>
+    <script src="src/tools/blur_brush.js"></script>
     <script src="src/tools/eraser.js"></script>
     <script src="src/tools/eraser-click.js"></script>
   <script src="src/tools/quadratic.js"></script>

--- a/src/app.js
+++ b/src/app.js
@@ -64,6 +64,9 @@ export class PaintApp {
       angle: 0,
       spacingRatio: 0.5,
     });
+    this.engine.register(makeAaLineBrush(this.store));
+    this.engine.register(makePixelBrush(this.store));
+    this.engine.register(makeBlurBrush(this.store));
     this.engine.register(makeEraser(this.store));
     this.engine.register(makeEraserClick(this.store));
     this.engine.register(makeEyedropper(this.store));

--- a/src/gui/tool-props.js
+++ b/src/gui/tool-props.js
@@ -77,6 +77,17 @@ export const toolPropDefs = {
       { name: 'angle', label: '角度', type: 'range', min: -180, max: 180, step: 1, default: 0 },
       { name: 'spacingRatio', label: '間隔', type: 'range', min: 0.1, max: 1, step: 0.05, default: 0.5 },
     ],
+    'aa-line-brush': [
+      { name: 'opacity', label: '不透明度', type: 'range', min: 0.1, max: 1, step: 0.05, default: 0.8 },
+    ],
+    'pixel-brush': [
+      { name: 'pixelSize', label: 'ピクセルサイズ', type: 'range', min: 1, max: 32, step: 1, default: 1 },
+    ],
+    'blur-brush': [
+      { name: 'sigma', label: 'ぼかしσ', type: 'range', min: 0.5, max: 10, step: 0.5, default: 3 },
+      { name: 'iterations', label: '回数', type: 'number', min: 1, max: 5, step: 1, default: 1 },
+      { name: 'spacingRatio', label: '間隔', type: 'range', min: 0.1, max: 1, step: 0.05, default: 0.6 },
+    ],
     eraser: [{ name: 'brushSize', label: 'サイズ', type: 'range', min: 1, max: 64, step: 1, default: 4 }],
     'eraser-click': [{ name: 'brushSize', label: 'サイズ', type: 'range', min: 1, max: 64, step: 1, default: 4 }],
     bucket: [{ name: 'primaryColor', label: '色', type: 'color', default: '#000000' }],


### PR DESCRIPTION
## Summary
- Add AA line, pixel and blur brush buttons before the eraser
- Register new tools in the engine
- Provide parameter controls for opacity, pixel size and blur options

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c6455d75a88324be1206cdeeeb25c0