### PR TITLE
Enable side panel resizing via drag

### DIFF
--- a/index.html
+++ b/index.html
@@ -122,11 +122,15 @@
         <div class="panel-footer"></div>
       </div>
 
+      <div id="leftResizer" class="panel-resizer"></div>
+
       <div id="canvasArea">
         <canvas id="base"></canvas>
         <canvas id="overlay"></canvas>
         <div id="editorLayer"></div>
       </div>
+
+      <div id="rightResizer" class="panel-resizer"></div>
 
       <div id="layerPanel" class="side-panel panel" data-name="レイヤー">
         <div class="panel-header"></div>

--- a/src/managers/dom-manager.js
+++ b/src/managers/dom-manager.js
@@ -6,7 +6,11 @@ export class DOMManager {
       editorLayer: document.getElementById("editorLayer"),
       stage: document.getElementById("stage"),
       header: document.querySelector("header"),
+      leftResizer: document.getElementById("leftResizer"),
+      rightResizer: document.getElementById("rightResizer"),
     };
+    this.leftWidth = 200;
+    this.rightWidth = 250;
   }
 
   getCanvasArea() {
@@ -50,5 +54,45 @@ export class DOMManager {
       this.syncHeaderHeight();
       this.centerStageScroll();
     });
+
+    this.initPanelResizers();
+  }
+
+  initPanelResizers() {
+    const { stage, leftResizer, rightResizer } = this.elements;
+    if (!stage || !leftResizer || !rightResizer) return;
+
+    const update = () => {
+      stage.style.gridTemplateColumns = `${this.leftWidth}px 4px 1fr 4px ${this.rightWidth}px`;
+    };
+
+    const startDrag = (side, e) => {
+      e.preventDefault();
+      const startX = e.clientX;
+      const startLeft = this.leftWidth;
+      const startRight = this.rightWidth;
+
+      const onMove = ev => {
+        const dx = ev.clientX - startX;
+        if (side === 'left') {
+          this.leftWidth = Math.max(100, startLeft + dx);
+        } else {
+          this.rightWidth = Math.max(100, startRight - dx);
+        }
+        update();
+      };
+
+      const onUp = () => {
+        document.removeEventListener('mousemove', onMove);
+        document.removeEventListener('mouseup', onUp);
+      };
+      document.addEventListener('mousemove', onMove);
+      document.addEventListener('mouseup', onUp);
+    };
+
+    leftResizer.addEventListener('mousedown', e => startDrag('left', e));
+    rightResizer.addEventListener('mousedown', e => startDrag('right', e));
+
+    update();
   }
 }

--- a/styles.css
+++ b/styles.css
@@ -92,7 +92,7 @@ footer {
   background: #f6f6f6;
   overflow: hidden; /* scrollを削除 */
   display: grid;
-  grid-template-columns: 200px 1fr 250px; /* 左200px、中央可変、右250px */
+  grid-template-columns: 200px 4px 1fr 4px 250px; /* 左200px、中央可変、右250px */
   height: 100%;
 }
 
@@ -127,6 +127,12 @@ footer {
 
 #layerPanel {
   border-left: 1px solid #ddd;
+}
+
+.panel-resizer {
+  background: #ddd;
+  cursor: col-resize;
+  width: 4px;
 }
 
 #canvasArea {


### PR DESCRIPTION
## Summary
- Allow left and right side panels to be resized by dragging
- Add resize handles and update layout with CSS grid columns
- Handle resizer events in DOMManager

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c663775e408324a1c07c6079e76aea