### PR TITLE
Add map zoom controls and selection edit mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -124,10 +124,37 @@
 
       <div id="leftResizer" class="panel-resizer"></div>
 
-      <div id="canvasArea">
-        <canvas id="base"></canvas>
-        <canvas id="overlay"></canvas>
-        <div id="editorLayer"></div>
+      <div id="mapPanel">
+        <div id="mapControls" class="row">
+          <div class="map-controls-group">
+            <button id="mapZoomOut" type="button" aria-label="ズームアウト">－</button>
+            <input
+              id="mapZoomSlider"
+              type="range"
+              min="25"
+              max="400"
+              step="5"
+              value="100"
+              aria-label="ズーム倍率"
+            />
+            <span id="mapZoomValue" aria-live="polite">100%</span>
+            <button id="mapZoomIn" type="button" aria-label="ズームイン">＋</button>
+          </div>
+          <div class="map-controls-group" role="radiogroup" aria-label="編集範囲">
+            <label>
+              <input type="radio" name="editScope" value="map" checked />マップ編集
+            </label>
+            <label>
+              <input type="radio" name="editScope" value="cell" />セル編集
+            </label>
+          </div>
+        </div>
+
+        <div id="canvasArea">
+          <canvas id="base"></canvas>
+          <canvas id="overlay"></canvas>
+          <div id="editorLayer"></div>
+        </div>
       </div>
 
       <div id="rightResizer" class="panel-resizer"></div>

--- a/src/app.js
+++ b/src/app.js
@@ -1,6 +1,7 @@
 import { initToolbar, setToolCallbacks } from './gui/toolbar.js';
 import { initToolPropsPanel } from './gui/tool-props.js';
 import { initAdjustPanel, initLayerPanel, setAdjustCallbacks, setLayerCallbacks, initPanelHeaders } from './gui/panels.js';
+import { initMapControls, setMapControlCallbacks, updateEditModeControls, updateZoomControls } from './gui/map-controls.js';
 import { Engine } from './engine.js';
 import { layers, activeLayer, bmp, renderLayers, addLayer, deleteLayer } from './layer.js';
 import { initIO, initDocument, openImageFile, triggerSave, doCopy, doCut, handleClipboardItems, restoreSession, checkSession, saveSessionDebounced } from './io.js';
@@ -121,6 +122,7 @@ export class PaintApp {
     this.setupToolbarCallbacks();
     this.setupLayerCallbacks();
     this.setupAdjustmentCallbacks();
+    this.setupMapControls();
   }
 
   setupToolbarCallbacks() {
@@ -173,6 +175,25 @@ export class PaintApp {
         this.adjustmentManager.resetToDefaults();
         saveSessionDebounced();
       }
+    });
+  }
+
+  setupMapControls() {
+    initMapControls();
+    updateZoomControls(Math.round(this.viewport.zoom * 100));
+    updateEditModeControls(this.engine.editMode);
+    setMapControlCallbacks({
+      onZoomChange: zoom => {
+        const rect = window.base?.getBoundingClientRect?.();
+        if (rect) {
+          this.engine.zoomTo(zoom, { sx: rect.width / 2, sy: rect.height / 2 });
+        } else {
+          this.engine.zoomTo(zoom);
+        }
+      },
+      onModeChange: mode => {
+        this.engine.setEditMode(mode);
+      },
     });
   }
 

--- a/src/engine.js
+++ b/src/engine.js
@@ -3,6 +3,7 @@ import { clamp, dpr, resizeCanvasToDisplaySize } from './utils/helpers.js';
 import { cancelTextEditing, getActiveEditor } from './managers/text-editor.js';
 import { openImageFile } from './io.js';
 import { updateStatus, updateZoom } from './gui/statusbar.js';
+import { updateEditModeControls, updateZoomControls } from './gui/map-controls.js';
 import { selectTool } from './main.js';
 
 /* ===== history ===== */
@@ -40,6 +41,8 @@ export class Engine {
     this._preStrokeCanvas = null;
     this._pendingRect = null;
     this.filterPreview = null; // {canvas, x, y}
+    this.editMode = 'map';
+    this._pointerActive = false;
     this._bindEvents();
     this.requestRepaint = this.requestRepaint.bind(this);
 
@@ -78,6 +81,69 @@ export class Engine {
     const tid = this.store.getState().toolId;
     const ts = this.store.getToolState(tid);
     updateStatus(`x:${Math.floor(pos.img.x)}, y:${Math.floor(pos.img.y)}  線:${ts.primaryColor} 塗:${ts.secondaryColor}  幅:${ts.brushSize}`);
+  }
+
+  zoomTo(targetZoom, anchor = {}) {
+    const zoom = clamp(targetZoom, 0.1, 32);
+    const rect = window.base?.getBoundingClientRect?.();
+    const sx = anchor.sx ?? rect?.width / 2 ?? 0;
+    const sy = anchor.sy ?? rect?.height / 2 ?? 0;
+    const before = this.vp.screenToImage(sx, sy);
+    this.vp.zoom = zoom;
+    const after = this.vp.imageToScreen(before.x, before.y);
+    this.vp.panX += sx - after.x;
+    this.vp.panY += sy - after.y;
+    this.requestRepaint();
+  }
+
+  setEditMode(mode) {
+    const next = mode === 'cell' ? 'cell' : 'map';
+    if (this.editMode === next) return;
+    this.editMode = next;
+    if (next !== 'cell') {
+      this._pointerActive = false;
+    } else if (!this.selection) {
+      updateStatus('セル編集モード: 編集するセルを選択してください');
+    }
+    updateEditModeControls(this.editMode);
+    this.requestRepaint();
+  }
+
+  _shouldRestrictToSelection(toolId) {
+    if (this.editMode !== 'cell') return false;
+    if (toolId === 'select-rect') return false;
+    return true;
+  }
+
+  _clampPointerToSelection(pointer) {
+    const sel = this.selection?.rect;
+    if (!sel) return pointer;
+    const maxX = sel.x + sel.w;
+    const maxY = sel.y + sel.h;
+    const clampedX = clamp(pointer.img.x, sel.x, maxX);
+    const clampedY = clamp(pointer.img.y, sel.y, maxY);
+    if (clampedX === pointer.img.x && clampedY === pointer.img.y) return pointer;
+    return {
+      ...pointer,
+      img: { x: clampedX, y: clampedY },
+    };
+  }
+
+  _withSelectionClip(ctx, fn) {
+    const sel = this.selection?.rect;
+    if (!sel) {
+      fn(ctx);
+      return;
+    }
+    ctx.save();
+    ctx.beginPath();
+    ctx.rect(sel.x, sel.y, sel.w, sel.h);
+    ctx.clip();
+    try {
+      fn(ctx);
+    } finally {
+      ctx.restore();
+    }
   }
 
   beginStrokeSnapshot() {
@@ -198,7 +264,9 @@ export class Engine {
     }
     // エディタDOMの変換
     editorLayer.style.transform = `translate(${this.vp.panX}px, ${this.vp.panY}px) scale(${this.vp.zoom})`;
-    updateZoom(Math.round(this.vp.zoom * 100));
+    const zoomPct = Math.round(this.vp.zoom * 100);
+    updateZoom(zoomPct);
+    updateZoomControls(zoomPct);
   }
   drawAnts(octx, r) {
     octx.save();
@@ -284,6 +352,7 @@ export class Engine {
     if (!area) return;
     area.addEventListener("pointerdown", (e) => {
       const p = pointer(e);
+      this._pointerActive = false;
       if (e.button === 1 || (p.ctrl && e.button === 0)) {
         this.isPanning = true;
         this.lastS = { x: e.clientX, y: e.clientY };
@@ -291,13 +360,33 @@ export class Engine {
         base.style.cursor = "grabbing";
         return;
       }
-      this.current?.onPointerDown(this.ctx, p, this);
+      const tool = this.current;
+      if (!tool?.onPointerDown) return;
+      const ctx = this.ctx;
+      const toolId = this.store.getState().toolId;
+      if (this._shouldRestrictToSelection(toolId)) {
+        const selRect = this.selection?.rect;
+        if (!selRect) {
+          updateStatus('セル編集モード: 編集するセルを選択してください');
+          return;
+        }
+        if (!this.pointInRect(p.img, selRect)) {
+          updateStatus('セル編集モード: 選択範囲内で操作してください');
+          return;
+        }
+        const clamped = this._clampPointerToSelection(p);
+        this._withSelectionClip(ctx, (context) => tool.onPointerDown(context, clamped, this));
+      } else {
+        tool.onPointerDown(ctx, p, this);
+      }
+      this._pointerActive = true;
       this.requestRepaint();
       this.updateCursorInfo(p);
     });
 
     area.addEventListener("contextmenu", (e) => {
       e.preventDefault();
+      this._pointerActive = false;
       this.current?.cancel?.();
       this.requestRepaint();
     });
@@ -314,7 +403,23 @@ export class Engine {
         this.updateCursorInfo(p);
         return;
       }
-      this.current?.onPointerMove(this.ctx, p, this);
+      const tool = this.current;
+      const handler = tool?.onPointerMove;
+      if (handler) {
+        const ctx = this.ctx;
+        const toolId = this.store.getState().toolId;
+        if (this._shouldRestrictToSelection(toolId)) {
+          const selRect = this.selection?.rect;
+          if (!selRect) {
+            if (this._pointerActive) this._pointerActive = false;
+          } else {
+            const clamped = this._clampPointerToSelection(p);
+            this._withSelectionClip(ctx, (context) => handler(context, clamped, this));
+          }
+        } else {
+          handler(ctx, p, this);
+        }
+      }
       this.requestRepaint();
       this.updateCursorInfo(p);
     });
@@ -330,25 +435,41 @@ export class Engine {
         return;
       }
       const p = pointer(e);
-      this.current?.onPointerUp(this.ctx, p, this);
-      this.finishStrokeToHistory();
-      this.requestRepaint();
+      const tool = this.current;
+      const handler = tool?.onPointerUp;
+      let handled = false;
+      if (handler) {
+        const ctx = this.ctx;
+        const toolId = this.store.getState().toolId;
+        if (this._shouldRestrictToSelection(toolId)) {
+          const selRect = this.selection?.rect;
+          if (selRect && this._pointerActive) {
+            const clamped = this._clampPointerToSelection(p);
+            this._withSelectionClip(ctx, (context) => handler(context, clamped, this));
+            handled = true;
+          }
+        } else {
+          handler(ctx, p, this);
+          handled = true;
+        }
+      }
+      if (handled && this._pointerActive) {
+        this.finishStrokeToHistory();
+        this.requestRepaint();
+      }
+      this._pointerActive = false;
+      this.updateCursorInfo(p);
     });
     area.addEventListener(
       "wheel",
       (e) => {
         if (!(e.ctrlKey || e.metaKey)) return;
         e.preventDefault();
-        const rect = base.getBoundingClientRect();
+        const rect = window.base.getBoundingClientRect();
         const sx = e.clientX - rect.left,
           sy = e.clientY - rect.top;
-        const before = this.vp.screenToImage(sx, sy);
         const factor = e.deltaY > 0 ? 0.9 : 1.1;
-        this.vp.zoom = clamp(this.vp.zoom * factor, 0.1, 32);
-        const after = this.vp.imageToScreen(before.x, before.y);
-        this.vp.panX += sx - after.x;
-        this.vp.panY += sy - after.y;
-        this.requestRepaint();
+        this.zoomTo(this.vp.zoom * factor, { sx, sy });
       },
       { passive: false }
     );

--- a/src/gui/map-controls.js
+++ b/src/gui/map-controls.js
@@ -1,0 +1,89 @@
+import { clamp } from '../utils/helpers.js';
+
+let callbacks = {
+  onZoomChange: null,
+  onModeChange: null,
+};
+
+let sliderEl = null;
+let zoomValueEl = null;
+let zoomOutBtn = null;
+let zoomInBtn = null;
+let modeRadios = [];
+
+function updateZoomValue(percent) {
+  if (zoomValueEl) {
+    zoomValueEl.textContent = `${Math.round(percent)}%`;
+  }
+}
+
+function emitZoomFromSlider() {
+  if (!sliderEl) return;
+  const percent = Number(sliderEl.value);
+  updateZoomValue(percent);
+  callbacks.onZoomChange?.(percent / 100);
+}
+
+function adjustZoomByStep(step) {
+  if (!sliderEl) return;
+  const min = sliderEl.min ? Number(sliderEl.min) : 0;
+  const max = sliderEl.max ? Number(sliderEl.max) : 100;
+  const current = Number(sliderEl.value);
+  const next = clamp(current + step, min, max);
+  if (next === current) return;
+  sliderEl.value = String(next);
+  updateZoomValue(next);
+  callbacks.onZoomChange?.(next / 100);
+}
+
+export function initMapControls() {
+  sliderEl = document.getElementById('mapZoomSlider');
+  zoomValueEl = document.getElementById('mapZoomValue');
+  zoomOutBtn = document.getElementById('mapZoomOut');
+  zoomInBtn = document.getElementById('mapZoomIn');
+  modeRadios = Array.from(document.querySelectorAll("input[name='editScope']"));
+
+  sliderEl?.addEventListener('input', () => emitZoomFromSlider());
+  sliderEl?.addEventListener('change', () => emitZoomFromSlider());
+
+  const step = sliderEl?.step ? Number(sliderEl.step) : 10;
+  zoomOutBtn?.addEventListener('click', () => adjustZoomByStep(-step));
+  zoomInBtn?.addEventListener('click', () => adjustZoomByStep(step));
+
+  modeRadios.forEach((radio) =>
+    radio.addEventListener('change', () => {
+      if (radio.checked) {
+        callbacks.onModeChange?.(radio.value);
+      }
+    }),
+  );
+}
+
+export function setMapControlCallbacks(newCallbacks = {}) {
+  callbacks = { ...callbacks, ...newCallbacks };
+}
+
+export function updateZoomControls(percent) {
+  if (sliderEl) {
+    const min = sliderEl.min ? Number(sliderEl.min) : 0;
+    const max = sliderEl.max ? Number(sliderEl.max) : 100;
+    const clamped = clamp(percent, min, max);
+    if (Number(sliderEl.value) !== clamped) {
+      sliderEl.value = String(clamped);
+    }
+    updateZoomValue(clamped);
+  } else {
+    updateZoomValue(percent);
+  }
+}
+
+export function updateEditModeControls(mode) {
+  modeRadios.forEach((radio) => {
+    radio.checked = radio.value === mode;
+  });
+}
+
+export function getCurrentMode() {
+  const active = modeRadios.find((radio) => radio.checked);
+  return active?.value ?? 'map';
+}

--- a/src/tools/bucket.js
+++ b/src/tools/bucket.js
@@ -10,7 +10,7 @@ export function makeBucket(store) {
       const r = parseInt(h.slice(1, 3), 16),
         g = parseInt(h.slice(3, 5), 16),
         b = parseInt(h.slice(5, 7), 16);
-      const p = floodFill(
+      const patch = floodFill(
         ctx,
         bmp,
         Math.floor(ev.img.x),
@@ -18,7 +18,54 @@ export function makeBucket(store) {
         [r, g, b, 255],
         16,
       );
-      if (p) eng.history.pushPatch(p);
+      if (!patch) return;
+
+      if (eng.editMode === 'cell' && eng.selection?.rect) {
+        const sel = eng.selection.rect;
+        const { rect, before, after } = patch;
+        const beforeData = before.data;
+        const afterData = after.data;
+        let modifiedOutside = false;
+        let modifiedInside = false;
+        for (let y = 0; y < rect.h; y++) {
+          for (let x = 0; x < rect.w; x++) {
+            const gx = rect.x + x;
+            const gy = rect.y + y;
+            const idx = (y * rect.w + x) * 4;
+            const inside = eng.pointInRect({ x: gx, y: gy }, sel);
+            if (!inside) {
+              if (
+                afterData[idx] !== beforeData[idx] ||
+                afterData[idx + 1] !== beforeData[idx + 1] ||
+                afterData[idx + 2] !== beforeData[idx + 2] ||
+                afterData[idx + 3] !== beforeData[idx + 3]
+              ) {
+                afterData[idx] = beforeData[idx];
+                afterData[idx + 1] = beforeData[idx + 1];
+                afterData[idx + 2] = beforeData[idx + 2];
+                afterData[idx + 3] = beforeData[idx + 3];
+                modifiedOutside = true;
+              }
+            } else if (
+              !modifiedInside &&
+              (afterData[idx] !== beforeData[idx] ||
+                afterData[idx + 1] !== beforeData[idx + 1] ||
+                afterData[idx + 2] !== beforeData[idx + 2] ||
+                afterData[idx + 3] !== beforeData[idx + 3])
+            ) {
+              modifiedInside = true;
+            }
+          }
+        }
+        if (modifiedOutside) {
+          ctx.putImageData(after, rect.x, rect.y);
+        }
+        if (!modifiedInside) {
+          return;
+        }
+      }
+
+      eng.history.pushPatch(patch);
     },
     onPointerMove() {},
     onPointerUp() {},

--- a/styles.css
+++ b/styles.css
@@ -135,10 +135,55 @@ footer {
   width: 4px;
 }
 
+#mapPanel {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+}
+
+#mapControls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+  padding: 8px;
+  background: #f0f0f0;
+  border-bottom: 1px solid #ddd;
+  position: sticky;
+  top: 0;
+  z-index: 5;
+}
+
+.map-controls-group {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+#mapControls button {
+  min-width: 0;
+  padding: 4px 10px;
+}
+
+#mapControls input[type='range'] {
+  width: 140px;
+}
+
+#mapControls label {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  white-space: nowrap;
+}
+
 #canvasArea {
   position: relative;
   overflow: scroll; /* スクロールを中央エリアに移動 */
   background: #f6f6f6;
+  flex: 1 1 auto;
+  min-height: 0;
 }
 
 #canvasArea::-webkit-scrollbar {


### PR DESCRIPTION
## Summary
- add a control bar above the map area with zoom buttons/slider and a map vs cell edit toggle
- integrate the new controls with the engine to support zooming, editing locks for the selection, and bucket masking in cell mode
- restyle the central panel to accommodate the controls and keep the zoom UI in sync with viewport changes

## Testing
- Manual verification in browser (python -m http.server 8000)


------
https://chatgpt.com/codex/tasks/task_e_68d600caf7cc83249bdf100e927eae49