### PR TITLE
Add developer documentation and usage examples

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1,0 +1,70 @@
+# SimplePaint API Reference
+
+This document describes the public modules exposed by the SimplePaint runtime. It focuses on the contracts that third party tools and extensions can depend on when integrating with the application.
+
+## Core Engine
+
+### `src/core/engine.js`
+- **`Engine` class** – coordinates the lifecycle of the drawing session, including the canvas context stack, active tool, and history integration.
+- **`engine.useTool(toolId)`** – switches the active tool by id, validating against the registry.
+- **`engine.dispatch(action)`** – pushes structured actions into the history manager and mutates canvas state.
+
+### `src/core/store.js`
+- **`createStore(initialState)`** – creates a reactive store with `getState`, `setState`, and `subscribe` helpers.
+- **`store.watch(selector, callback)`** – subscribes to derived data changes without re-rendering the entire state tree.
+
+## Tool Registry
+
+### `src/tools/_base/registry.js`
+- **`registerTool(toolId, factory)`** – adds a tool factory to the registry.
+- **`getTool(toolId)`** – resolves a tool by id and throws if the tool is missing.
+- **`listTools()`** – returns an array of `{ id, category }` entries assembled from the manifest and registry.
+
+### `src/tools/_base/manifest.js`
+- `DEFAULT_TOOL_MANIFEST` – frozen array of categories that define the canonical ordering of tools inside the UI.
+- `createCategory(id, label, toolIds)` – helper to define manifest categories.
+- `createToolEntry(id, factory)` – helper to create manifest entries for custom tooling.
+
+## Events
+
+### `src/core/event-bus.js`
+- **`createEventBus()`** – returns a strongly typed pub/sub instance.
+- **`bus.emit(event, payload)`** – broadcasts an event to listeners.
+- **`bus.on(event, handler)`** – attaches a listener and returns an unsubscribe function.
+
+## Layers
+
+### `src/core/layer.js`
+- **`createLayer(options)`** – creates a layer descriptor with metadata, transformation, and draw callbacks.
+- **`layer.render(ctx)`** – paints layer content onto a provided canvas context.
+
+## Utilities
+
+### `src/utils/canvas/`
+- Canvas helpers for managing raster buffers, overlays, and exporting user selections.
+
+### `src/utils/geometry/`
+- Vector math helpers, collision detection, and shape tessellation utilities shared across tools.
+
+### `src/utils/color-space.js`
+- Conversions between RGB, HSV, and L*a*b* colour spaces.
+
+### `src/utils/math/`
+- Interpolation, noise, random distributions, and smoothing kernels.
+
+### `src/utils/path.js`
+- Bézier helpers, polyline simplification, and cursor snapping logic.
+
+## Tool Interface
+
+See [tool-interface.md](./tool-interface.md) for the contract that custom tools must satisfy.
+
+## Extensibility Hooks
+
+- **Tool manifest augmentation** – call `registerTool` and append new entries to the manifest to expose custom brushes.
+- **Store watchers** – use `store.watch` to react to viewport or layer changes without mutating state directly.
+- **Event bus** – subscribe to `pointer:*` events for global gestures or overlays.
+
+## Versioning
+
+The API follows semantic versioning. Breaking changes are announced in the `docs/PROGRESS.md` changelog. Extensions should pin to a specific minor version to avoid regressions.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,52 @@
+# SimplePaint Architecture Overview
+
+SimplePaint is composed of four layers: the rendering core, shared utilities, interactive tools, and the presentation layer exposed by `index.html`. The architecture is intentionally modular so that tools and extensions can be developed in isolation and registered through the manifest system.
+
+## 1. Rendering Core
+
+Located in `src/core/`, the rendering core manages state, history, and drawing orchestration.
+
+- **`engine.js`** – wraps the canvas contexts, provides the tool execution pipeline, and integrates the `HistoryManager` for undo/redo.
+- **`store.js`** – lightweight observable store inspired by Zustand; exposes `watch` helpers for derived subscriptions.
+- **`viewport.js`** – translates between screen and canvas coordinates, supports zooming/panning.
+- **`layer.js`** – describes drawable layers and their render order.
+- **`event-bus.js`** – centralised pub/sub for user interactions and tool events.
+
+## 2. Tooling System
+
+Tools live under `src/tools/` and are grouped by category. Each tool exports a factory function that returns the lifecycle handlers expected by the engine (`onPointerDown`, `onPointerMove`, `onPointerUp`, `drawPreview`, etc.).
+
+The manifest (`src/tools/_base/manifest.js`) provides a declarative catalogue. The registry (`src/tools/_base/registry.js`) ensures that each tool id is unique and retrievable at runtime. Tools can be swapped or extended without touching engine internals.
+
+## 3. Utilities
+
+The `src/utils/` directory houses shared functionality:
+
+- `canvas/` – frame buffer helpers and compositing utilities.
+- `geometry/` – vector math, intersections, and curve helpers.
+- `image/processing.js` – blur, sharpen, and convolutions for raster tools.
+- `color-space.js` – conversions and colour blending helpers.
+- `math/` – easing curves, noise generators, and statistics.
+- `path.js` – polyline, Bézier, and stroke outline operations.
+
+## 4. Presentation Layer
+
+`index.html` bootstraps the engine, loads the default tool manifest, and wires up UI controls. Styling lives in `styles.css`. This layer is intentionally thin; most behaviour is encapsulated in the engine and tools to make future UI rewrites easy.
+
+## Data Flow
+
+1. User interaction triggers DOM events.
+2. Events are forwarded to the engine, which looks up the current tool via the registry.
+3. Tool handlers mutate the store or draw to scratch canvases.
+4. The engine commits results to the active layer and records a history entry.
+5. The viewport and presentation layer respond to store changes and re-render as needed.
+
+## Extensibility
+
+- **Add a new tool** by creating a module in the appropriate category and registering it in the manifest.
+- **Inject custom state** by extending the store with additional slices and watchers.
+- **Listen to events** via the event bus to build overlays or collaborative features.
+
+## Testing Strategy
+
+Core modules are deterministic and can be unit tested by importing the functions directly. Tool behaviour is best validated through integration tests that simulate pointer events against an offscreen canvas. See `test/` for existing suites and use them as templates for new tests.

--- a/docs/examples/custom-filter.js
+++ b/docs/examples/custom-filter.js
@@ -1,0 +1,14 @@
+import { applyKernel } from '../../src/utils/image/processing.js';
+
+const bloomKernel = [
+  0, 0.05, 0,
+  0.05, 0.6, 0.05,
+  0, 0.05, 0,
+];
+
+export function applyBloom(canvasCtx) {
+  const { width, height } = canvasCtx.canvas;
+  const imageData = canvasCtx.getImageData(0, 0, width, height);
+  const output = applyKernel(imageData, bloomKernel, 3);
+  canvasCtx.putImageData(output, 0, 0);
+}

--- a/docs/examples/custom-tool.js
+++ b/docs/examples/custom-tool.js
@@ -1,0 +1,35 @@
+import { registerTool } from '../../src/tools/_base/registry.js';
+import { createToolEntry } from '../../src/tools/_base/manifest.js';
+
+function createStarBrush(context) {
+  const stamp = new Path2D('M12 2 L15 9 H22 L17 13 L19 20 L12 16 L5 20 L7 13 L2 9 H9 Z');
+
+  return {
+    id: 'star-brush',
+    cursor: 'pointer',
+    onPointerDown(event, engine) {
+      this.onPointerMove(event, engine);
+    },
+    onPointerMove(event, engine) {
+      const { canvasCtx } = engine.getContexts();
+      canvasCtx.save();
+      canvasCtx.translate(event.x, event.y);
+      canvasCtx.scale(context.brush.size / 24, context.brush.size / 24);
+      canvasCtx.fill(stamp);
+      canvasCtx.restore();
+    },
+    onPointerUp() {},
+    drawPreview(overlayCtx) {
+      overlayCtx.strokeStyle = 'rgba(255,255,255,0.5)';
+      overlayCtx.beginPath();
+      overlayCtx.arc(context.pointer.x, context.pointer.y, context.brush.size / 2, 0, Math.PI * 2);
+      overlayCtx.stroke();
+    },
+  };
+}
+
+export function registerStarBrush(manifest) {
+  registerTool('star-brush', createStarBrush);
+  manifest.push(createToolEntry('star-brush'));
+  return manifest;
+}

--- a/docs/tool-development.md
+++ b/docs/tool-development.md
@@ -1,0 +1,102 @@
+# Tool Development Guide
+
+This guide explains how to build a custom tool for SimplePaint using the manifest and registry infrastructure.
+
+## 1. Project Setup
+
+1. Create a new file inside the correct category under `src/tools/`. For example, `src/tools/drawing/spray.js`.
+2. Export a factory function that returns the tool lifecycle handlers.
+
+```javascript
+// src/tools/drawing/spray.js
+import { sampleGaussian } from '../../utils/math/random.js';
+
+export default function createSprayTool(context) {
+  const points = [];
+
+  return {
+    id: 'spray',
+    cursor: 'crosshair',
+    onPointerDown(event, engine) {
+      points.length = 0;
+      this.onPointerMove(event, engine);
+    },
+    onPointerMove(event, engine) {
+      const { canvasCtx } = engine.getContexts();
+      for (let i = 0; i < 16; i += 1) {
+        const [dx, dy] = sampleGaussian(0, 12);
+        canvasCtx.fillRect(event.x + dx, event.y + dy, 1, 1);
+      }
+    },
+    onPointerUp() {},
+    drawPreview(overlayCtx) {
+      overlayCtx.strokeStyle = 'rgba(255,255,255,0.3)';
+      overlayCtx.strokeRect(context.pointer.x - 12, context.pointer.y - 12, 24, 24);
+    },
+  };
+}
+```
+
+## 2. Registering the Tool
+
+Add the tool to the manifest and registry. The manifest controls ordering, while the registry provides the actual factory.
+
+```javascript
+// src/tools/_base/manifest.js
+import { createCategory, createToolEntry } from './manifest-helpers.js';
+import createSprayTool from '../drawing/spray.js';
+
+export const DEFAULT_TOOL_MANIFEST = [
+  // ...existing categories
+  createCategory('drawing', 'Drawing tools', [
+    createToolEntry('pencil'),
+    createToolEntry('brush'),
+    createToolEntry('spray'), // new entry
+  ]),
+];
+
+// src/tools/_base/registry.js
+import { registerTool } from './registry-core.js';
+import createSprayTool from '../drawing/spray.js';
+
+registerTool('spray', createSprayTool);
+```
+
+## 3. Tool Context
+
+The factory receives a `context` object containing helpers:
+
+- `store` – shared global state.
+- `viewport` – coordinate transforms.
+- `history` – undo/redo integration.
+- `eventBus` – publish/subscribe to application events.
+
+Use these helpers instead of importing modules directly when possible; this keeps tools portable.
+
+## 4. State Management
+
+- Use `store.getState()` to read reactive data.
+- Use `store.setState()` to update slices. Group related changes to avoid redundant renders.
+- Use `store.watch(selector, callback)` for derived state such as layer opacity or viewport zoom.
+
+## 5. Drawing Strategy
+
+- Prefer drawing into offscreen buffers for complex brushes, then compositing onto the main canvas.
+- When painting directly, wrap operations in `engine.beginStroke()` / `engine.endStroke()` if available to ensure correct history snapshots.
+- Provide a `drawPreview` function for hover outlines or overlays.
+
+## 6. Performance Tips
+
+- Cache expensive calculations between pointer events.
+- Use utilities from `src/utils/` (geometry, math, image) instead of re-implementing helpers.
+- Debounce history entries if the tool emits long-running strokes.
+
+## 7. Testing
+
+Add unit or integration tests under `test/tools/` that simulate pointer events and assert canvas mutations. Use the existing pencil tests as a template.
+
+## 8. Distribution
+
+Third-party tool bundles should export a function that receives the engine context and registers tools via `registerTool`. Document required assets and configuration in your README.
+
+For more background on the runtime, review the [Architecture Overview](./architecture.md) and [API Reference](./API.md).


### PR DESCRIPTION
## Summary
- document the runtime API surface and architecture structure for SimplePaint
- provide a detailed tool development guide aligned with the manifest and registry systems
- add example modules demonstrating how to register custom tools and filters

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e6414a7a6883249c9b8be2b798b518