### PR TITLE
Prevent tool panel hiding from collapsing the canvas

### DIFF
--- a/src/gui/tool-props.js
+++ b/src/gui/tool-props.js
@@ -132,53 +132,65 @@ export function initToolPropsPanel(store, engine) {
   const render = (id) => {
     const defs = toolPropDefs[id] || [];
     body.innerHTML = '';
-    defs.forEach((d) => {
-      const wrap = document.createElement('div');
-      wrap.className = 'prop-item';
-      const label = document.createElement('label');
-      label.textContent = d.label;
-      label.style.display = 'block';
-      let input;
-      if (d.type === 'select') {
-        input = document.createElement('select');
-        d.options.forEach((o) => {
-          const opt = document.createElement('option');
-          opt.value = o.value;
-          opt.textContent = o.label;
-          input.appendChild(opt);
-        });
-      } else {
-        input = document.createElement('input');
-        input.type = d.type;
-        if (d.min !== undefined) input.min = d.min;
-        if (d.max !== undefined) input.max = d.max;
-        if (d.step !== undefined) input.step = d.step;
-      }
-      const state = store.getToolState(id);
-      const val = state[d.name] ?? d.default;
-      if (d.type === 'checkbox') input.checked = !!val; else input.value = val;
-      const evt = d.type === 'checkbox' ? 'change' : 'input';
-      input.addEventListener(evt, () => {
-        const v = d.type === 'checkbox' ? input.checked : (d.type === 'number' ? parseFloat(input.value) : input.value);
-        store.setToolState(id, { [d.name]: v });
-        if (d.name === 'antialias') engine?.requestRepaint?.();
-        if (id === 'text') {
-          const ed = getActiveEditor();
-          if (ed) {
-            if (d.name === 'fontFamily') ed.style.fontFamily = v;
-            if (d.name === 'fontSize') {
-              ed.style.fontSize = v + 'px';
-              ed.style.lineHeight = Math.round(v * 1.4) + 'px';
-            }
-            if (d.name === 'primaryColor') ed.style.color = v;
-          }
+
+    if (defs.length === 0) {
+      const empty = document.createElement('div');
+      empty.className = 'prop-empty';
+      empty.textContent = 'このツールに設定はありません';
+      body.appendChild(empty);
+    } else {
+      defs.forEach((d) => {
+        const wrap = document.createElement('div');
+        wrap.className = 'prop-item';
+        const label = document.createElement('label');
+        label.textContent = d.label;
+        label.style.display = 'block';
+        let input;
+        if (d.type === 'select') {
+          input = document.createElement('select');
+          d.options.forEach((o) => {
+            const opt = document.createElement('option');
+            opt.value = o.value;
+            opt.textContent = o.label;
+            input.appendChild(opt);
+          });
+        } else {
+          input = document.createElement('input');
+          input.type = d.type;
+          if (d.min !== undefined) input.min = d.min;
+          if (d.max !== undefined) input.max = d.max;
+          if (d.step !== undefined) input.step = d.step;
         }
+        const state = store.getToolState(id);
+        const val = state[d.name] ?? d.default;
+        if (d.type === 'checkbox') input.checked = !!val; else input.value = val;
+        const evt = d.type === 'checkbox' ? 'change' : 'input';
+        input.addEventListener(evt, () => {
+          const v = d.type === 'checkbox'
+            ? input.checked
+            : (d.type === 'number' ? parseFloat(input.value) : input.value);
+          store.setToolState(id, { [d.name]: v });
+          if (d.name === 'antialias') engine?.requestRepaint?.();
+          if (id === 'text') {
+            const ed = getActiveEditor();
+            if (ed) {
+              if (d.name === 'fontFamily') ed.style.fontFamily = v;
+              if (d.name === 'fontSize') {
+                ed.style.fontSize = v + 'px';
+                ed.style.lineHeight = Math.round(v * 1.4) + 'px';
+              }
+              if (d.name === 'primaryColor') ed.style.color = v;
+            }
+          }
+        });
+        wrap.appendChild(label);
+        wrap.appendChild(input);
+        body.appendChild(wrap);
       });
-      wrap.appendChild(label);
-      wrap.appendChild(input);
-      body.appendChild(wrap);
-    });
-    panel.style.display = defs.length ? 'block' : 'none';
+    }
+
+    panel.style.display = 'flex';
+    panel.classList.toggle('no-tool-props', defs.length === 0);
   };
 
   render(store.getState().toolId);

--- a/styles.css
+++ b/styles.css
@@ -121,6 +121,20 @@ footer {
   padding: 8px;
 }
 
+.side-panel.no-tool-props .panel-body {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+}
+
+.prop-empty {
+  color: #666;
+  font-size: 12px;
+  text-align: center;
+  line-height: 1.5;
+}
+
 #leftPanel {
   border-right: 1px solid #ddd;
 }


### PR DESCRIPTION
## Summary
- keep the tool property panel mounted and show a placeholder when a tool has no adjustable options so the layout retains the canvas column width
- add styling for the placeholder state so the empty panel communicates the lack of settings without affecting interaction

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e6567663088324bbb1ec591c160ab2