### PR TITLE
Add opacity controls and clarify tool property ranges

### DIFF
--- a/src/core/store.js
+++ b/src/core/store.js
@@ -220,6 +220,7 @@ export const toolDefaults = Object.freeze({
   secondaryColor: '#ffffff',
   fillOn: true,
   antialias: false,
+  opacity: 1,
   nurbsWeight: 1,
   fontFamily: 'system-ui, sans-serif',
   fontSize: 24,

--- a/src/gui/tool-props.js
+++ b/src/gui/tool-props.js
@@ -12,21 +12,85 @@ const DEFAULT_TOOL_PALETTE = Object.freeze([
 ]);
 
 const strokeProps = [
-  { name: 'brushSize', label: '線幅', type: 'range', min: 1, max: 64, step: 1, default: 4 },
-  { name: 'primaryColor', label: '線色', type: 'color', default: '#000000' },
+  {
+    name: 'brushSize',
+    label: '線幅',
+    type: 'range',
+    min: 1,
+    max: 64,
+    step: 1,
+    default: 4,
+    hint: 'ストロークの太さを調整します（1〜64px）。',
+  },
+  {
+    name: 'primaryColor',
+    label: '線色',
+    type: 'color',
+    default: '#000000',
+    hint: '線を描画するときに使用する色を選びます。',
+  },
 ];
 
+const opacityProp = {
+  name: 'opacity',
+  label: '不透明度',
+  type: 'range',
+  min: 0.05,
+  max: 1,
+  step: 0.05,
+  default: 1,
+  hint: '線の透け具合を設定します（0.05でほぼ透明〜1で完全不透明）。',
+};
+
 const smoothProps = [
-  { name: 'smoothAlpha', label: '滑らかさ', type: 'range', min: 0, max: 1, step: 0.05, default: 0.55 },
-  { name: 'spacingRatio', label: '間隔', type: 'range', min: 0.1, max: 1, step: 0.05, default: 0.4 },
+  {
+    name: 'smoothAlpha',
+    label: '滑らかさ',
+    type: 'range',
+    min: 0,
+    max: 1,
+    step: 0.05,
+    default: 0.55,
+    hint: '補間の強さを制御し、値が高いほどブラシ跡が滑らかになります（0〜1）。',
+  },
+  {
+    name: 'spacingRatio',
+    label: 'スタンプ間隔',
+    type: 'range',
+    min: 0.1,
+    max: 1,
+    step: 0.05,
+    default: 0.4,
+    hint: 'ブラシスタンプの間隔を倍率で指定します（0.1〜1）。低いほど密になります。',
+  },
 ];
 
 const fillProps = [
-  { name: 'secondaryColor', label: '塗色', type: 'color', default: '#ffffff' },
-  { name: 'fillOn', label: '塗り', type: 'checkbox', default: true },
+  {
+    name: 'secondaryColor',
+    label: '塗り色',
+    type: 'color',
+    default: '#ffffff',
+    hint: '矩形や楕円の塗りつぶしに使う色を選びます。',
+  },
+  {
+    name: 'fillOn',
+    label: '塗りを有効にする',
+    type: 'checkbox',
+    default: true,
+    hint: 'オンにすると図形を塗りつぶし、オフで輪郭のみ描画します。',
+  },
 ];
 
-const aaProp = [{ name: 'antialias', label: 'AA', type: 'checkbox', default: false }];
+const aaProp = [
+  {
+    name: 'antialias',
+    label: 'アンチエイリアス',
+    type: 'checkbox',
+    default: false,
+    hint: 'オンでエッジを滑らかに補間し、オフでピクセルをくっきり描画します。',
+  },
+];
 
 const textProps = [
   {
@@ -40,82 +104,380 @@ const textProps = [
       { value: 'monospace', label: 'Monospace' },
     ],
     default: 'system-ui, sans-serif',
+    hint: 'テキストツールで使用するフォントファミリを選択します。',
   },
-  { name: 'fontSize', label: 'サイズ', type: 'number', min: 8, max: 200, step: 1, default: 24 },
+  {
+    name: 'fontSize',
+    label: 'サイズ',
+    type: 'number',
+    min: 8,
+    max: 200,
+    step: 1,
+    default: 24,
+    hint: 'テキストの文字サイズ（ポイント相当）を 8〜200px で指定します。',
+  },
 ];
 
-const nurbsProp = [{ name: 'nurbsWeight', label: '重み', type: 'number', step: 0.1, default: 1 }];
+const nurbsProp = [
+  {
+    name: 'nurbsWeight',
+    label: '制御点の重み',
+    type: 'number',
+    step: 0.1,
+    default: 1,
+    hint: '制御点の影響度を調整します。値が大きいほどその点へカーブが引き寄せられます。',
+  },
+];
 
 export const toolPropDefs = {
-  pencil: [...strokeProps],
-  'pencil-click': [...strokeProps],
-  brush: [...strokeProps, ...smoothProps],
-  smooth: [...strokeProps],
-  'texture-brush': [...strokeProps, { name: 'spacingRatio', label: '間隔', type: 'range', min: 0.1, max: 1, step: 0.05, default: 0.4 }],
-    watercolor: [
-      ...strokeProps,
-      { name: 'diffusion', label: '拡散D', type: 'range', min: 0.05, max: 0.2, step: 0.01, default: 0.1 },
-      { name: 'evaporation', label: '蒸発E', type: 'range', min: 0.01, max: 0.05, step: 0.01, default: 0.02 },
-    ],
-    'tess-stroke': [...strokeProps],
-    minimal: [
-      { name: 'brushSize', label: '線幅', type: 'range', min: 1, max: 6, step: 1, default: 4 },
-      { name: 'primaryColor', label: '線色', type: 'color', default: '#000000' },
-    ],
-    calligraphy: [
-      ...strokeProps,
-      { name: 'penAngle', label: '角度', type: 'range', min: 0, max: 180, step: 1, default: 45 },
-      { name: 'kappa', label: '縦横比', type: 'range', min: 1.5, max: 3, step: 0.1, default: 2 },
-    ],
-    bristle: [
-      { name: 'brushSize', label: '線幅', type: 'range', min: 1, max: 64, step: 1, default: 8 },
-      { name: 'count', label: '本数', type: 'range', min: 4, max: 12, step: 1, default: 8 },
-    ],
-    scatter: [...strokeProps],
-    smudge: [
-      { name: 'radius', label: 'サイズ', type: 'range', min: 1, max: 64, step: 1, default: 16 },
-      { name: 'strength', label: '強さ', type: 'range', min: 0, max: 1, step: 0.05, default: 0.5 },
-      {
-        name: 'dirMode',
-        label: '方向',
-        type: 'select',
-        options: [
-          { value: 'tangent', label: '接線' },
-          { value: 'angle', label: '角度指定' },
-        ],
-        default: 'tangent',
-      },
-      { name: 'angle', label: '角度', type: 'range', min: -180, max: 180, step: 1, default: 0 },
-      { name: 'spacingRatio', label: '間隔', type: 'range', min: 0.1, max: 1, step: 0.05, default: 0.5 },
-    ],
-    'aa-line-brush': [
-      { name: 'opacity', label: '不透明度', type: 'range', min: 0.1, max: 1, step: 0.05, default: 0.8 },
-    ],
-    'pixel-brush': [
-      { name: 'pixelSize', label: 'ピクセルサイズ', type: 'range', min: 1, max: 32, step: 1, default: 1 },
-    ],
-    'blur-brush': [
-      { name: 'sigma', label: 'ぼかしσ', type: 'range', min: 0.5, max: 10, step: 0.5, default: 3 },
-      { name: 'iterations', label: '回数', type: 'number', min: 1, max: 5, step: 1, default: 1 },
-      { name: 'spacingRatio', label: '間隔', type: 'range', min: 0.1, max: 1, step: 0.05, default: 0.6 },
-    ],
-    'edge-aware-paint': [
-      { name: 'primaryColor', label: '線色', type: 'color', default: '#000000' },
-      { name: 'tau', label: '勾配しきい値', type: 'range', min: 1, max: 100, step: 1, default: 30 },
-      { name: 'radius', label: '半径', type: 'range', min: 1, max: 64, step: 1, default: 16 },
-      { name: 'boundaryPad', label: '境界緩衝', type: 'range', min: 0, max: 3, step: 1, default: 1 },
-      { name: 'strength', label: '強さ', type: 'range', min: 0, max: 1, step: 0.05, default: 0.6 },
-      { name: 'spacingRatio', label: '間隔', type: 'range', min: 0.1, max: 1, step: 0.05, default: 0.5 },
-    ],
-    'noise-displaced': [
-      ...strokeProps,
-      { name: 'ndAmplitude', label: '変位振幅', type: 'range', min: 0, max: 6, step: 0.1, default: 2 },
-      { name: 'ndFrequency', label: '変位周波数', type: 'range', min: 0.02, max: 1, step: 0.01, default: 0.25 },
-      { name: 'ndSeed', label: 'シード', type: 'number', step: 1, default: 0 },
-    ],
-    eraser: [{ name: 'brushSize', label: 'サイズ', type: 'range', min: 1, max: 64, step: 1, default: 4 }],
-    'eraser-click': [{ name: 'brushSize', label: 'サイズ', type: 'range', min: 1, max: 64, step: 1, default: 4 }],
-    bucket: [{ name: 'primaryColor', label: '色', type: 'color', default: '#000000' }],
+  pencil: [...strokeProps, opacityProp],
+  'pencil-click': [...strokeProps, opacityProp],
+  brush: [...strokeProps, opacityProp, ...smoothProps],
+  smooth: [...strokeProps, ...smoothProps],
+  'texture-brush': [
+    ...strokeProps,
+    {
+      name: 'spacingRatio',
+      label: 'スタンプ間隔',
+      type: 'range',
+      min: 0.1,
+      max: 1,
+      step: 0.05,
+      default: 0.4,
+      hint: 'テクスチャスタンプの間隔を倍率で調整します（0.1〜1）。低いほど密に押されます。',
+    },
+  ],
+  watercolor: [
+    ...strokeProps,
+    {
+      name: 'diffusion',
+      label: '拡散量',
+      type: 'range',
+      min: 0.05,
+      max: 0.2,
+      step: 0.01,
+      default: 0.1,
+      hint: '水彩の滲みの広がりを指定します（0.05〜0.20）。大きいほどぼんやり広がります。',
+    },
+    {
+      name: 'evaporation',
+      label: '蒸発速度',
+      type: 'range',
+      min: 0.01,
+      max: 0.05,
+      step: 0.01,
+      default: 0.02,
+      hint: '水分が乾く速さを制御します（0.01〜0.05）。高いほど乾きが速く濃く残ります。',
+    },
+  ],
+  'tess-stroke': [...strokeProps],
+  minimal: [
+    {
+      name: 'brushSize',
+      label: '線幅（ミニマル）',
+      type: 'range',
+      min: 1,
+      max: 6,
+      step: 1,
+      default: 4,
+      hint: '極細線ブラシの太さを 1〜6px で調整します。',
+    },
+    {
+      name: 'primaryColor',
+      label: '線色',
+      type: 'color',
+      default: '#000000',
+      hint: '描画に使用する色を選びます。',
+    },
+  ],
+  calligraphy: [
+    ...strokeProps,
+    {
+      name: 'penAngle',
+      label: 'ペン角度',
+      type: 'range',
+      min: 0,
+      max: 180,
+      step: 1,
+      default: 45,
+      hint: 'ペン先の回転角度を 0〜180° で指定します。傾きを変えると太さの出方が変化します。',
+    },
+    {
+      name: 'kappa',
+      label: '長短径比',
+      type: 'range',
+      min: 1.5,
+      max: 3,
+      step: 0.1,
+      default: 2,
+      hint: '筆先の長径と短径の比率を設定します。値が高いほど楕円が細長くなります。',
+    },
+    {
+      name: 'w_min',
+      label: '最小幅',
+      type: 'range',
+      min: 1,
+      max: 64,
+      step: 1,
+      default: 1,
+      hint: 'ペン先の短径を 1〜64px で制限します。細さの下限を決め筆致を安定させます。',
+    },
+  ],
+  bristle: [
+    {
+      name: 'brushSize',
+      label: '束の幅',
+      type: 'range',
+      min: 1,
+      max: 64,
+      step: 1,
+      default: 8,
+      hint: 'ブラシ全体の太さを 1〜64px で調整します。',
+    },
+    {
+      name: 'count',
+      label: '毛の本数',
+      type: 'range',
+      min: 4,
+      max: 12,
+      step: 1,
+      default: 8,
+      hint: 'スタンプ内の毛束の本数を設定します。多いほど密で滑らかになります。',
+    },
+  ],
+  scatter: [...strokeProps],
+  smudge: [
+    {
+      name: 'radius',
+      label: 'ぼかし半径',
+      type: 'range',
+      min: 1,
+      max: 64,
+      step: 1,
+      default: 16,
+      hint: '周囲から色を引き延ばす半径を 1〜64px で指定します。大きいほど広範囲を混ぜます。',
+    },
+    {
+      name: 'strength',
+      label: '混ざり強度',
+      type: 'range',
+      min: 0,
+      max: 1,
+      step: 0.05,
+      default: 0.5,
+      hint: 'ドラッグした方向へどれだけ色を引きずるかを 0〜1 で制御します。',
+    },
+    {
+      name: 'dirMode',
+      label: '方向モード',
+      type: 'select',
+      options: [
+        { value: 'tangent', label: '接線方向' },
+        { value: 'angle', label: '角度指定' },
+      ],
+      default: 'tangent',
+      hint: 'ストローク方向に従うか、角度を固定するかを選びます。',
+    },
+    {
+      name: 'angle',
+      label: '固定角度',
+      type: 'range',
+      min: -180,
+      max: 180,
+      step: 1,
+      default: 0,
+      hint: '方向モードが角度指定のときに使用する角度を −180〜180° で設定します。',
+    },
+    {
+      name: 'spacingRatio',
+      label: 'サンプル間隔',
+      type: 'range',
+      min: 0.1,
+      max: 1,
+      step: 0.05,
+      default: 0.5,
+      hint: 'ストローク中のサンプリング間隔を倍率で調整します（0.1〜1）。',
+    },
+  ],
+  'aa-line-brush': [
+    {
+      name: 'opacity',
+      label: '不透明度',
+      type: 'range',
+      min: 0.1,
+      max: 1,
+      step: 0.05,
+      default: 0.8,
+      hint: 'アンチエイリアス線の濃さを指定します（0.1〜1）。',
+    },
+  ],
+  'pixel-brush': [
+    {
+      name: 'pixelSize',
+      label: 'ピクセルサイズ',
+      type: 'range',
+      min: 1,
+      max: 32,
+      step: 1,
+      default: 1,
+      hint: '描画されるピクセル単位の大きさを 1〜32px で指定します。',
+    },
+  ],
+  'blur-brush': [
+    {
+      name: 'sigma',
+      label: 'ぼかし強度',
+      type: 'range',
+      min: 0.5,
+      max: 10,
+      step: 0.5,
+      default: 3,
+      hint: 'ガウシアンぼかしのσ値（0.5〜10）です。大きいほどぼけが広がります。',
+    },
+    {
+      name: 'iterations',
+      label: '反復回数',
+      type: 'number',
+      min: 1,
+      max: 5,
+      step: 1,
+      default: 1,
+      hint: '処理を重ねる回数です。増やすと滑らかになりますが処理が重くなります。',
+    },
+    {
+      name: 'spacingRatio',
+      label: 'スタンプ間隔',
+      type: 'range',
+      min: 0.1,
+      max: 1,
+      step: 0.05,
+      default: 0.6,
+      hint: 'ぼかしスタンプの間隔を調整します（0.1〜1）。',
+    },
+  ],
+  'edge-aware-paint': [
+    {
+      name: 'primaryColor',
+      label: '線色',
+      type: 'color',
+      default: '#000000',
+      hint: '塗りつぶす際のベースカラーを選択します。',
+    },
+    {
+      name: 'tau',
+      label: 'エッジ感度',
+      type: 'range',
+      min: 1,
+      max: 100,
+      step: 1,
+      default: 30,
+      hint: 'エッジ検出の閾値を設定します（1〜100）。低いほど細かな輪郭を検知します。',
+    },
+    {
+      name: 'radius',
+      label: '探索半径',
+      type: 'range',
+      min: 1,
+      max: 64,
+      step: 1,
+      default: 16,
+      hint: 'エッジを探索する半径を 1〜64px で指定します。',
+    },
+    {
+      name: 'boundaryPad',
+      label: '境界余白',
+      type: 'range',
+      min: 0,
+      max: 3,
+      step: 1,
+      default: 1,
+      hint: '境界へどれだけ余白を取るかを 0〜3px で調整します。',
+    },
+    {
+      name: 'strength',
+      label: '適用強度',
+      type: 'range',
+      min: 0,
+      max: 1,
+      step: 0.05,
+      default: 0.6,
+      hint: '塗りの影響力を 0〜1 で制御します。高いほど輪郭を強く保護します。',
+    },
+    {
+      name: 'spacingRatio',
+      label: 'スタンプ間隔',
+      type: 'range',
+      min: 0.1,
+      max: 1,
+      step: 0.05,
+      default: 0.5,
+      hint: 'ブラシを打つ頻度を倍率で調整します（0.1〜1）。',
+    },
+  ],
+  'noise-displaced': [
+    ...strokeProps,
+    {
+      name: 'ndAmplitude',
+      label: '変位振幅',
+      type: 'range',
+      min: 0,
+      max: 6,
+      step: 0.1,
+      default: 2,
+      hint: 'ノイズ変位の強さを 0〜6px で調整します。',
+    },
+    {
+      name: 'ndFrequency',
+      label: '変位周波数',
+      type: 'range',
+      min: 0.02,
+      max: 1,
+      step: 0.01,
+      default: 0.25,
+      hint: 'ノイズの細かさを制御します（0.02〜1）。高いほど細かな揺らぎになります。',
+    },
+    {
+      name: 'ndSeed',
+      label: 'シード値',
+      type: 'number',
+      step: 1,
+      default: 0,
+      hint: 'ノイズパターンを決める乱数シードです。同じ値なら結果が再現されます。',
+    },
+  ],
+  eraser: [
+    {
+      name: 'brushSize',
+      label: '消し幅',
+      type: 'range',
+      min: 1,
+      max: 64,
+      step: 1,
+      default: 4,
+      hint: '消しゴムの太さを 1〜64px で指定します。',
+    },
+  ],
+  'eraser-click': [
+    {
+      name: 'brushSize',
+      label: '消し幅',
+      type: 'range',
+      min: 1,
+      max: 64,
+      step: 1,
+      default: 4,
+      hint: 'クリック単位で削除する円の直径を決めます。',
+    },
+  ],
+  bucket: [
+    {
+      name: 'primaryColor',
+      label: '塗り色',
+      type: 'color',
+      default: '#000000',
+      hint: '塗りつぶしに使用する色を選びます。',
+    },
+  ],
   line: [...strokeProps, ...aaProp],
   rect: [...strokeProps, ...fillProps, ...aaProp],
   ellipse: [...strokeProps, ...fillProps, ...aaProp],
@@ -328,12 +690,24 @@ export function initToolPropsPanel(store, engine) {
         if (d.step !== undefined) input.step = d.step;
       }
       const val = state[d.name] ?? d.default;
-      if (d.type === 'checkbox') input.checked = !!val; else input.value = val;
-      const evt = d.type === 'checkbox' ? 'change' : 'input';
+      if (d.type === 'checkbox') {
+        input.checked = !!val;
+      } else if (val !== undefined && val !== null) {
+        input.value = String(val);
+      } else if (d.default !== undefined && d.type !== 'checkbox') {
+        input.value = String(d.default);
+      }
+      const evt = d.type === 'checkbox' || d.type === 'select' ? 'change' : 'input';
       input.addEventListener(evt, () => {
-        const v = d.type === 'checkbox'
-          ? input.checked
-          : (d.type === 'number' ? parseFloat(input.value) : input.value);
+        let v;
+        if (d.type === 'checkbox') {
+          v = input.checked;
+        } else if (d.type === 'number' || d.type === 'range') {
+          const parsed = parseFloat(input.value);
+          v = Number.isFinite(parsed) ? parsed : d.default;
+        } else {
+          v = input.value;
+        }
         store.setToolState(id, { [d.name]: v });
         if (d.name === 'antialias') engine?.requestRepaint?.();
         if (id === 'text') {
@@ -350,6 +724,15 @@ export function initToolPropsPanel(store, engine) {
       });
       wrap.appendChild(label);
       wrap.appendChild(input);
+      if (d.hint) {
+        const hint = document.createElement('div');
+        hint.className = 'prop-hint';
+        hint.textContent = d.hint;
+        wrap.appendChild(hint);
+        if (input instanceof HTMLElement) {
+          input.title = d.hint;
+        }
+      }
       body.appendChild(wrap);
     });
 

--- a/src/tools/drawing/brush.js
+++ b/src/tools/drawing/brush.js
@@ -128,9 +128,13 @@ export function makeBrush(store) {
       last = { ...ev.img };
 
       const s = store.getToolState(id);
+      const opacity = Number.isFinite(s.opacity)
+        ? Math.min(Math.max(s.opacity, 0), 1)
+        : 1;
       ctx.save();
       ctx.lineCap = "round";
       ctx.lineJoin = "round";
+      ctx.globalAlpha = opacity;
       ctx.strokeStyle = s.primaryColor;
       ctx.lineWidth = s.brushSize;
       ctx.beginPath();
@@ -151,10 +155,14 @@ export function makeBrush(store) {
       if (!drawing || !last) return;
       const p = { ...ev.img };
       const s = store.getToolState(id);
+      const opacity = Number.isFinite(s.opacity)
+        ? Math.min(Math.max(s.opacity, 0), 1)
+        : 1;
 
       ctx.save();
       ctx.lineCap = "round";
       ctx.lineJoin = "round";
+      ctx.globalAlpha = opacity;
       ctx.strokeStyle = s.primaryColor;
       ctx.lineWidth = s.brushSize;
       ctx.beginPath();

--- a/src/tools/drawing/pencil-click.js
+++ b/src/tools/drawing/pencil-click.js
@@ -40,9 +40,13 @@ export function makePencilClick(store) {
         };
         function stroke(ctx, img) {
           const s = store.getToolState(id);
+          const opacity = Number.isFinite(s.opacity)
+            ? Math.min(Math.max(s.opacity, 0), 1)
+            : 1;
           ctx.save();
           ctx.lineCap = "round";
           ctx.lineJoin = "round";
+          ctx.globalAlpha = opacity;
           ctx.strokeStyle = s.primaryColor;
           ctx.lineWidth = s.brushSize;
           ctx.beginPath();

--- a/src/tools/drawing/pencil.js
+++ b/src/tools/drawing/pencil.js
@@ -32,9 +32,13 @@ export function makePencil(store) {
         };
         function stroke(ctx, img) {
           const s = store.getToolState(id);
+          const opacity = Number.isFinite(s.opacity)
+            ? Math.min(Math.max(s.opacity, 0), 1)
+            : 1;
           ctx.save();
           ctx.lineCap = 'round';
           ctx.lineJoin = 'round';
+          ctx.globalAlpha = opacity;
           ctx.strokeStyle = s.primaryColor;
           ctx.lineWidth = s.brushSize;
           ctx.beginPath();

--- a/styles.css
+++ b/styles.css
@@ -142,6 +142,21 @@ footer {
   margin-bottom: 8px;
 }
 
+.prop-item {
+  margin-bottom: 12px;
+}
+
+.prop-item:last-child {
+  margin-bottom: 0;
+}
+
+.prop-hint {
+  color: #777;
+  font-size: 11px;
+  line-height: 1.4;
+  margin-top: 4px;
+}
+
 .prop-palette-section {
   margin-top: 12px;
 }


### PR DESCRIPTION
## Summary
- add an opacity slider for the pencil and brush tools and persist the default value
- document tool property ranges/effects with inline hints and render them in the panel UI
- style the property panel for the new guidance text and ensure numeric sliders parse correctly

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e67c22bfe08324b48b9107b6903dfa